### PR TITLE
feat: implement Warrior class with Fighter specialty (issue #81)

### DIFF
--- a/server/constants/class_specialties.go
+++ b/server/constants/class_specialties.go
@@ -1,0 +1,124 @@
+// Package constants holds game constants for character creation and validation.
+package constants
+
+// ClassSpecialty represents a specialty within a class.
+type ClassSpecialty struct {
+	ID          string
+	Name        string
+	Description string
+}
+
+// ClassConfig holds the starting configuration for a class.
+type ClassConfig struct {
+	Class              string
+	Specialty          string
+	Description        string
+	StartingSkills     map[string]int  // skill_id -> level
+	StartingTalents    []string        // talent_ids (max 4)
+	StatBonuses        struct {
+		Strength     int
+		Dexterity    int
+		Constitution int
+		Intelligence int
+		Wisdom       int
+	}
+}
+
+// ClassSpecialties maps classes to their available specialties.
+var ClassSpecialties = map[string][]ClassSpecialty{
+	"warrior": {
+		{ID: "fighter", Name: "Fighter", Description: "The bread-and-butter warrior. Solid, reliable combat with blades and brawling."},
+		{ID: "knight", Name: "Knight", Description: "Heavy armor specialist with defensive tactics."},
+		{ID: "berserker", Name: "Berserker", Description: "Raw aggression and devastating offense."},
+	},
+	"chef": {
+		{ID: "pizzaiolo", Name: "Pizzaiolo", Description: "Master of pizza combat and mutant cuisine."},
+	},
+	"mystic": {
+		{ID: "elementalist", Name: "Elementalist", Description: "Wielder of elemental magic."},
+	},
+	"tinkerer": {
+		{ID: "mechanic", Name: "Mechanic", Description: "Tech salvage and gadget specialist."},
+	},
+	"trader": {
+		{ID: "merchant", Name: "Merchant", Description: "Economy and NPC interactions."},
+	},
+	"brawler": {
+		{ID: "street_fighter", Name: "Street Fighter", Description: "Unarmed combat specialist."},
+	},
+	"vine_climber": {
+		{ID: "scout", Name: "Scout", Description: "Stealth and climbing."},
+	},
+	"survivor": {
+		{ID: "generalist", Name: "Generalist", Description: "Jack of all trades."},
+	},
+}
+
+// StartingConfigs maps class+specialty to starting configuration.
+var StartingConfigs = map[string]ClassConfig{
+	"warrior:fighter": {
+		Class:        "warrior",
+		Specialty:    "fighter",
+		Description:  "Defenders of survivor enclaves, battle-hardened veterans.",
+		StartingSkills: map[string]int{
+			"blades":   1,
+			"brawling": 1,
+		},
+		StartingTalents: []string{"slash", "parry", "smash", "crash"},
+		StatBonuses: struct {
+			Strength     int
+			Dexterity    int
+			Constitution int
+			Intelligence int
+			Wisdom       int
+		}{
+			Strength:     3,
+			Constitution: 1,
+		},
+	},
+	"survivor:generalist": {
+		Class:        "survivor",
+		Specialty:    "generalist",
+		Description:  "A versatile survivor who can adapt to any situation.",
+		StartingSkills: map[string]int{
+			"brawling": 1,
+		},
+		StartingTalents: []string{"crash"},
+		StatBonuses: struct {
+			Strength     int
+			Dexterity    int
+			Constitution int
+			Intelligence int
+			Wisdom       int
+		}{
+			Constitution: 2,
+			Wisdom:       2,
+		},
+	},
+}
+
+// GetClassConfig returns the starting configuration for a class+specialty.
+// Falls back to survivor:generalist if class not found.
+func GetClassConfig(class, specialty string) ClassConfig {
+	key := class + ":" + specialty
+	if config, ok := StartingConfigs[key]; ok {
+		return config
+	}
+	// Try just class with default specialty
+	if specialties, ok := ClassSpecialties[class]; ok && len(specialties) > 0 {
+		key = class + ":" + specialties[0].ID
+		if config, ok := StartingConfigs[key]; ok {
+			return config
+		}
+	}
+	// Fallback to survivor
+	return StartingConfigs["survivor:generalist"]
+}
+
+// GetSpecialty returns the specialty for a class, or the first available one.
+func GetSpecialty(class string) string {
+	if specialties, ok := ClassSpecialties[class]; ok && len(specialties) > 0 {
+		return specialties[0].ID
+	}
+	return "generalist"
+}

--- a/server/constants/class_specialties_test.go
+++ b/server/constants/class_specialties_test.go
@@ -1,0 +1,141 @@
+package constants
+
+import (
+	"testing"
+)
+
+func TestGetClassConfig_WarriorFighter(t *testing.T) {
+	config := GetClassConfig("warrior", "fighter")
+
+	if config.Class != "warrior" {
+		t.Errorf("Expected class 'warrior', got '%s'", config.Class)
+	}
+	if config.Specialty != "fighter" {
+		t.Errorf("Expected specialty 'fighter', got '%s'", config.Specialty)
+	}
+
+	// Check starting skills
+	if config.StartingSkills["blades"] != 1 {
+		t.Errorf("Expected blades level 1, got %d", config.StartingSkills["blades"])
+	}
+	if config.StartingSkills["brawling"] != 1 {
+		t.Errorf("Expected brawling level 1, got %d", config.StartingSkills["brawling"])
+	}
+
+	// Check starting talents
+	expectedTalents := []string{"slash", "parry", "smash", "crash"}
+	if len(config.StartingTalents) != len(expectedTalents) {
+		t.Errorf("Expected %d talents, got %d", len(expectedTalents), len(config.StartingTalents))
+	}
+	for i, talent := range expectedTalents {
+		if config.StartingTalents[i] != talent {
+			t.Errorf("Expected talent[%d] '%s', got '%s'", i, talent, config.StartingTalents[i])
+		}
+	}
+
+	// Check stat bonuses
+	if config.StatBonuses.Strength != 3 {
+		t.Errorf("Expected Strength bonus 3, got %d", config.StatBonuses.Strength)
+	}
+	if config.StatBonuses.Constitution != 1 {
+		t.Errorf("Expected Constitution bonus 1, got %d", config.StatBonuses.Constitution)
+	}
+}
+
+func TestGetClassConfig_FallbackToSurvivor(t *testing.T) {
+	// Unknown class should fallback to survivor:generalist
+	config := GetClassConfig("unknown_class", "unknown_specialty")
+
+	if config.Class != "survivor" {
+		t.Errorf("Expected fallback to survivor class, got '%s'", config.Class)
+	}
+	if config.Specialty != "generalist" {
+		t.Errorf("Expected fallback to generalist specialty, got '%s'", config.Specialty)
+	}
+}
+
+func TestGetClassConfig_ClassWithDefaultSpecialty(t *testing.T) {
+	// Requesting just "warrior" should return first specialty (fighter)
+	config := GetClassConfig("warrior", "")
+
+	// Should still get fighter config
+	if config.Class != "warrior" {
+		t.Errorf("Expected class 'warrior', got '%s'", config.Class)
+	}
+	// Fighter is the first specialty for warrior
+	if config.Specialty != "fighter" {
+		t.Errorf("Expected specialty 'fighter', got '%s'", config.Specialty)
+	}
+}
+
+func TestGetSpecialty_Warrior(t *testing.T) {
+	specialty := GetSpecialty("warrior")
+	if specialty != "fighter" {
+		t.Errorf("Expected 'fighter' as default warrior specialty, got '%s'", specialty)
+	}
+}
+
+func TestGetSpecialty_UnknownClass(t *testing.T) {
+	specialty := GetSpecialty("unknown_class")
+	if specialty != "generalist" {
+		t.Errorf("Expected 'generalist' as fallback specialty, got '%s'", specialty)
+	}
+}
+
+func TestClassSpecialties_WarriorHasFighter(t *testing.T) {
+	specialties, ok := ClassSpecialties["warrior"]
+	if !ok {
+		t.Fatal("Expected warrior class to have specialties")
+	}
+
+	found := false
+	for _, s := range specialties {
+		if s.ID == "fighter" {
+			found = true
+			if s.Name != "Fighter" {
+				t.Errorf("Expected Fighter name, got '%s'", s.Name)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected fighter specialty in warrior class")
+	}
+}
+
+func TestClassSpecialties_AllClassesHaveSpecialties(t *testing.T) {
+	classes := []string{"warrior", "chef", "mystic", "tinkerer", "trader", "brawler", "vine_climber", "survivor"}
+
+	for _, class := range classes {
+		specialties, ok := ClassSpecialties[class]
+		if !ok {
+			t.Errorf("Class '%s' missing from ClassSpecialties", class)
+			continue
+		}
+		if len(specialties) == 0 {
+			t.Errorf("Class '%s' has no specialties defined", class)
+		}
+	}
+}
+
+func TestStartingConfigs_WarriorFighterStatBonuses(t *testing.T) {
+	config := GetClassConfig("warrior", "fighter")
+
+	// Warrior fighter should have STR+3, CON+1
+	if config.StatBonuses.Strength != 3 {
+		t.Errorf("Expected Strength bonus 3, got %d", config.StatBonuses.Strength)
+	}
+	if config.StatBonuses.Constitution != 1 {
+		t.Errorf("Expected Constitution bonus 1, got %d", config.StatBonuses.Constitution)
+	}
+	// DEX, INT, WIS should be 0
+	if config.StatBonuses.Dexterity != 0 {
+		t.Errorf("Expected Dexterity bonus 0, got %d", config.StatBonuses.Dexterity)
+	}
+	if config.StatBonuses.Intelligence != 0 {
+		t.Errorf("Expected Intelligence bonus 0, got %d", config.StatBonuses.Intelligence)
+	}
+	if config.StatBonuses.Wisdom != 0 {
+		t.Errorf("Expected Wisdom bonus 0, got %d", config.StatBonuses.Wisdom)
+	}
+}

--- a/server/constants/warrior_fighter_test.go
+++ b/server/constants/warrior_fighter_test.go
@@ -1,0 +1,83 @@
+package constants
+
+import (
+	"testing"
+)
+
+func TestWarriorFighterStartingConfig(t *testing.T) {
+	// Test that warrior class gets fighter specialty by default
+	config := GetClassConfig("warrior", "")
+
+	if config.Class != "warrior" {
+		t.Errorf("Expected class 'warrior', got '%s'", config.Class)
+	}
+	if config.Specialty != "fighter" {
+		t.Errorf("Expected specialty 'fighter', got '%s'", config.Specialty)
+	}
+
+	// Test starting skills
+	if config.StartingSkills["blades"] != 1 {
+		t.Errorf("Expected blades level 1, got %d", config.StartingSkills["blades"])
+	}
+	if config.StartingSkills["brawling"] != 1 {
+		t.Errorf("Expected brawling level 1, got %d", config.StartingSkills["brawling"])
+	}
+
+	// Test starting talents
+	expectedTalents := []string{"slash", "parry", "smash", "crash"}
+	if len(config.StartingTalents) != len(expectedTalents) {
+		t.Errorf("Expected %d talents, got %d", len(expectedTalents), len(config.StartingTalents))
+	}
+	for i, talent := range expectedTalents {
+		if config.StartingTalents[i] != talent {
+			t.Errorf("Expected talent[%d] '%s', got '%s'", i, talent, config.StartingTalents[i])
+		}
+	}
+
+	// Test stat bonuses
+	if config.StatBonuses.Strength != 3 {
+		t.Errorf("Expected Strength bonus 3, got %d", config.StatBonuses.Strength)
+	}
+	if config.StatBonuses.Constitution != 1 {
+		t.Errorf("Expected Constitution bonus 1, got %d", config.StatBonuses.Constitution)
+	}
+	if config.StatBonuses.Dexterity != 0 {
+		t.Errorf("Expected Dexterity bonus 0, got %d", config.StatBonuses.Dexterity)
+	}
+	if config.StatBonuses.Intelligence != 0 {
+		t.Errorf("Expected Intelligence bonus 0, got %d", config.StatBonuses.Intelligence)
+	}
+	if config.StatBonuses.Wisdom != 0 {
+		t.Errorf("Expected Wisdom bonus 0, got %d", config.StatBonuses.Wisdom)
+	}
+}
+
+func TestWarriorFighterExplicitSpecialty(t *testing.T) {
+	// Test that explicitly requesting fighter specialty works
+	config := GetClassConfig("warrior", "fighter")
+
+	if config.Class != "warrior" {
+		t.Errorf("Expected class 'warrior', got '%s'", config.Class)
+	}
+	if config.Specialty != "fighter" {
+		t.Errorf("Expected specialty 'fighter', got '%s'", config.Specialty)
+	}
+}
+
+func TestWarriorOtherSpecialties(t *testing.T) {
+	// Test that warrior has multiple specialties defined
+	specialties, ok := ClassSpecialties["warrior"]
+	if !ok {
+		t.Fatal("Expected warrior class to have specialties defined")
+	}
+
+	// Should have at least fighter (more specialties like knight, berserker planned)
+	if len(specialties) < 1 {
+		t.Error("Warrior should have at least one specialty")
+	}
+
+	// First specialty should be fighter
+	if specialties[0].ID != "fighter" {
+		t.Errorf("Expected first specialty 'fighter', got '%s'", specialties[0].ID)
+	}
+}

--- a/server/db/character.go
+++ b/server/db/character.go
@@ -47,6 +47,8 @@ type Character struct {
 	Race string `json:"race,omitempty"`
 	// Class holds the value of the "class" field.
 	Class string `json:"class,omitempty"`
+	// Class specialty (e.g., fighter for warrior)
+	Specialty string `json:"specialty,omitempty"`
 	// Level holds the value of the "level" field.
 	Level int `json:"level,omitempty"`
 	// Constitution holds the value of the "constitution" field.
@@ -98,9 +100,15 @@ type CharacterEdges struct {
 	Room *Room `json:"room,omitempty"`
 	// NpcTemplate holds the value of the npcTemplate edge.
 	NpcTemplate *NPCTemplate `json:"npcTemplate,omitempty"`
+	// AvailableTalents holds the value of the available_talents edge.
+	AvailableTalents []*AvailableTalent `json:"available_talents,omitempty"`
+	// Skills holds the value of the skills edge.
+	Skills []*CharacterSkill `json:"skills,omitempty"`
+	// Talents holds the value of the talents edge.
+	Talents []*CharacterTalent `json:"talents,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [3]bool
+	loadedTypes [6]bool
 }
 
 // UserOrErr returns the User value or an error if the edge
@@ -136,6 +144,33 @@ func (e CharacterEdges) NpcTemplateOrErr() (*NPCTemplate, error) {
 	return nil, &NotLoadedError{edge: "npcTemplate"}
 }
 
+// AvailableTalentsOrErr returns the AvailableTalents value or an error if the edge
+// was not loaded in eager-loading.
+func (e CharacterEdges) AvailableTalentsOrErr() ([]*AvailableTalent, error) {
+	if e.loadedTypes[3] {
+		return e.AvailableTalents, nil
+	}
+	return nil, &NotLoadedError{edge: "available_talents"}
+}
+
+// SkillsOrErr returns the Skills value or an error if the edge
+// was not loaded in eager-loading.
+func (e CharacterEdges) SkillsOrErr() ([]*CharacterSkill, error) {
+	if e.loadedTypes[4] {
+		return e.Skills, nil
+	}
+	return nil, &NotLoadedError{edge: "skills"}
+}
+
+// TalentsOrErr returns the Talents value or an error if the edge
+// was not loaded in eager-loading.
+func (e CharacterEdges) TalentsOrErr() ([]*CharacterTalent, error) {
+	if e.loadedTypes[5] {
+		return e.Talents, nil
+	}
+	return nil, &NotLoadedError{edge: "talents"}
+}
+
 // scanValues returns the types for scanning values from sql.Rows.
 func (*Character) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
@@ -145,7 +180,7 @@ func (*Character) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullBool)
 		case character.FieldID, character.FieldCurrentRoomId, character.FieldStartingRoomId, character.FieldHitpoints, character.FieldMaxHitpoints, character.FieldStamina, character.FieldMaxStamina, character.FieldMana, character.FieldMaxMana, character.FieldLevel, character.FieldConstitution, character.FieldStrength, character.FieldDexterity, character.FieldIntelligence, character.FieldWisdom, character.FieldSkillBlades, character.FieldSkillStaves, character.FieldSkillKnives, character.FieldSkillMartial, character.FieldSkillBrawling, character.FieldSkillTech, character.FieldSkillLightArmor, character.FieldSkillClothArmor, character.FieldSkillHeavyArmor:
 			values[i] = new(sql.NullInt64)
-		case character.FieldName, character.FieldPassword, character.FieldRace, character.FieldClass, character.FieldGender, character.FieldDescription:
+		case character.FieldName, character.FieldPassword, character.FieldRace, character.FieldClass, character.FieldSpecialty, character.FieldGender, character.FieldDescription:
 			values[i] = new(sql.NullString)
 		case character.ForeignKeys[0]: // character_npc_template
 			values[i] = new(sql.NullString)
@@ -257,6 +292,12 @@ func (_m *Character) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field class", values[i])
 			} else if value.Valid {
 				_m.Class = value.String
+			}
+		case character.FieldSpecialty:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field specialty", values[i])
+			} else if value.Valid {
+				_m.Specialty = value.String
 			}
 		case character.FieldLevel:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -409,6 +450,21 @@ func (_m *Character) QueryNpcTemplate() *NPCTemplateQuery {
 	return NewCharacterClient(_m.config).QueryNpcTemplate(_m)
 }
 
+// QueryAvailableTalents queries the "available_talents" edge of the Character entity.
+func (_m *Character) QueryAvailableTalents() *AvailableTalentQuery {
+	return NewCharacterClient(_m.config).QueryAvailableTalents(_m)
+}
+
+// QuerySkills queries the "skills" edge of the Character entity.
+func (_m *Character) QuerySkills() *CharacterSkillQuery {
+	return NewCharacterClient(_m.config).QuerySkills(_m)
+}
+
+// QueryTalents queries the "talents" edge of the Character entity.
+func (_m *Character) QueryTalents() *CharacterTalentQuery {
+	return NewCharacterClient(_m.config).QueryTalents(_m)
+}
+
 // Update returns a builder for updating this Character.
 // Note that you need to call Character.Unwrap() before calling this method if this Character
 // was returned from a transaction, and the transaction was committed or rolled back.
@@ -473,6 +529,9 @@ func (_m *Character) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("class=")
 	builder.WriteString(_m.Class)
+	builder.WriteString(", ")
+	builder.WriteString("specialty=")
+	builder.WriteString(_m.Specialty)
 	builder.WriteString(", ")
 	builder.WriteString("level=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Level))

--- a/server/db/character/character.go
+++ b/server/db/character/character.go
@@ -40,6 +40,8 @@ const (
 	FieldRace = "race"
 	// FieldClass holds the string denoting the class field in the database.
 	FieldClass = "class"
+	// FieldSpecialty holds the string denoting the specialty field in the database.
+	FieldSpecialty = "specialty"
 	// FieldLevel holds the string denoting the level field in the database.
 	FieldLevel = "level"
 	// FieldConstitution holds the string denoting the constitution field in the database.
@@ -80,6 +82,12 @@ const (
 	EdgeRoom = "room"
 	// EdgeNpcTemplate holds the string denoting the npctemplate edge name in mutations.
 	EdgeNpcTemplate = "npcTemplate"
+	// EdgeAvailableTalents holds the string denoting the available_talents edge name in mutations.
+	EdgeAvailableTalents = "available_talents"
+	// EdgeSkills holds the string denoting the skills edge name in mutations.
+	EdgeSkills = "skills"
+	// EdgeTalents holds the string denoting the talents edge name in mutations.
+	EdgeTalents = "talents"
 	// Table holds the table name of the character in the database.
 	Table = "characters"
 	// UserTable is the table that holds the user relation/edge.
@@ -103,6 +111,25 @@ const (
 	NpcTemplateInverseTable = "npc_templates"
 	// NpcTemplateColumn is the table column denoting the npcTemplate relation/edge.
 	NpcTemplateColumn = "character_npc_template"
+	// AvailableTalentsTable is the table that holds the available_talents relation/edge. The primary key declared below.
+	AvailableTalentsTable = "character_available_talents"
+	// AvailableTalentsInverseTable is the table name for the AvailableTalent entity.
+	// It exists in this package in order to avoid circular dependency with the "availabletalent" package.
+	AvailableTalentsInverseTable = "available_talents"
+	// SkillsTable is the table that holds the skills relation/edge.
+	SkillsTable = "character_skills"
+	// SkillsInverseTable is the table name for the CharacterSkill entity.
+	// It exists in this package in order to avoid circular dependency with the "characterskill" package.
+	SkillsInverseTable = "character_skills"
+	// SkillsColumn is the table column denoting the skills relation/edge.
+	SkillsColumn = "character_skills"
+	// TalentsTable is the table that holds the talents relation/edge.
+	TalentsTable = "character_talents"
+	// TalentsInverseTable is the table name for the CharacterTalent entity.
+	// It exists in this package in order to avoid circular dependency with the "charactertalent" package.
+	TalentsInverseTable = "character_talents"
+	// TalentsColumn is the table column denoting the talents relation/edge.
+	TalentsColumn = "character_talents"
 )
 
 // Columns holds all SQL columns for character fields.
@@ -122,6 +149,7 @@ var Columns = []string{
 	FieldMaxMana,
 	FieldRace,
 	FieldClass,
+	FieldSpecialty,
 	FieldLevel,
 	FieldConstitution,
 	FieldGender,
@@ -146,10 +174,14 @@ var Columns = []string{
 var ForeignKeys = []string{
 	"character_npc_template",
 	"room_characters",
-	"skill_characters",
-	"talent_characters",
 	"user_characters",
 }
+
+var (
+	// AvailableTalentsPrimaryKey and AvailableTalentsColumn2 are the table columns denoting the
+	// primary key for the available_talents relation (M2M).
+	AvailableTalentsPrimaryKey = []string{"character_id", "available_talent_id"}
+)
 
 // ValidColumn reports if the column name is valid (part of the table columns).
 func ValidColumn(column string) bool {
@@ -297,6 +329,11 @@ func ByClass(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldClass, opts...).ToFunc()
 }
 
+// BySpecialty orders the results by the specialty field.
+func BySpecialty(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSpecialty, opts...).ToFunc()
+}
+
 // ByLevel orders the results by the level field.
 func ByLevel(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLevel, opts...).ToFunc()
@@ -402,6 +439,48 @@ func ByNpcTemplateField(field string, opts ...sql.OrderTermOption) OrderOption {
 		sqlgraph.OrderByNeighborTerms(s, newNpcTemplateStep(), sql.OrderByField(field, opts...))
 	}
 }
+
+// ByAvailableTalentsCount orders the results by available_talents count.
+func ByAvailableTalentsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newAvailableTalentsStep(), opts...)
+	}
+}
+
+// ByAvailableTalents orders the results by available_talents terms.
+func ByAvailableTalents(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newAvailableTalentsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// BySkillsCount orders the results by skills count.
+func BySkillsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newSkillsStep(), opts...)
+	}
+}
+
+// BySkills orders the results by skills terms.
+func BySkills(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newSkillsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByTalentsCount orders the results by talents count.
+func ByTalentsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newTalentsStep(), opts...)
+	}
+}
+
+// ByTalents orders the results by talents terms.
+func ByTalents(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTalentsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
 func newUserStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
@@ -421,5 +500,26 @@ func newNpcTemplateStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(NpcTemplateInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2O, false, NpcTemplateTable, NpcTemplateColumn),
+	)
+}
+func newAvailableTalentsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(AvailableTalentsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, AvailableTalentsTable, AvailableTalentsPrimaryKey...),
+	)
+}
+func newSkillsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(SkillsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, SkillsTable, SkillsColumn),
+	)
+}
+func newTalentsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TalentsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, TalentsTable, TalentsColumn),
 	)
 }

--- a/server/db/character/where.go
+++ b/server/db/character/where.go
@@ -124,6 +124,11 @@ func Class(v string) predicate.Character {
 	return predicate.Character(sql.FieldEQ(FieldClass, v))
 }
 
+// Specialty applies equality check predicate on the "specialty" field. It's identical to SpecialtyEQ.
+func Specialty(v string) predicate.Character {
+	return predicate.Character(sql.FieldEQ(FieldSpecialty, v))
+}
+
 // Level applies equality check predicate on the "level" field. It's identical to LevelEQ.
 func Level(v int) predicate.Character {
 	return predicate.Character(sql.FieldEQ(FieldLevel, v))
@@ -797,6 +802,81 @@ func ClassEqualFold(v string) predicate.Character {
 // ClassContainsFold applies the ContainsFold predicate on the "class" field.
 func ClassContainsFold(v string) predicate.Character {
 	return predicate.Character(sql.FieldContainsFold(FieldClass, v))
+}
+
+// SpecialtyEQ applies the EQ predicate on the "specialty" field.
+func SpecialtyEQ(v string) predicate.Character {
+	return predicate.Character(sql.FieldEQ(FieldSpecialty, v))
+}
+
+// SpecialtyNEQ applies the NEQ predicate on the "specialty" field.
+func SpecialtyNEQ(v string) predicate.Character {
+	return predicate.Character(sql.FieldNEQ(FieldSpecialty, v))
+}
+
+// SpecialtyIn applies the In predicate on the "specialty" field.
+func SpecialtyIn(vs ...string) predicate.Character {
+	return predicate.Character(sql.FieldIn(FieldSpecialty, vs...))
+}
+
+// SpecialtyNotIn applies the NotIn predicate on the "specialty" field.
+func SpecialtyNotIn(vs ...string) predicate.Character {
+	return predicate.Character(sql.FieldNotIn(FieldSpecialty, vs...))
+}
+
+// SpecialtyGT applies the GT predicate on the "specialty" field.
+func SpecialtyGT(v string) predicate.Character {
+	return predicate.Character(sql.FieldGT(FieldSpecialty, v))
+}
+
+// SpecialtyGTE applies the GTE predicate on the "specialty" field.
+func SpecialtyGTE(v string) predicate.Character {
+	return predicate.Character(sql.FieldGTE(FieldSpecialty, v))
+}
+
+// SpecialtyLT applies the LT predicate on the "specialty" field.
+func SpecialtyLT(v string) predicate.Character {
+	return predicate.Character(sql.FieldLT(FieldSpecialty, v))
+}
+
+// SpecialtyLTE applies the LTE predicate on the "specialty" field.
+func SpecialtyLTE(v string) predicate.Character {
+	return predicate.Character(sql.FieldLTE(FieldSpecialty, v))
+}
+
+// SpecialtyContains applies the Contains predicate on the "specialty" field.
+func SpecialtyContains(v string) predicate.Character {
+	return predicate.Character(sql.FieldContains(FieldSpecialty, v))
+}
+
+// SpecialtyHasPrefix applies the HasPrefix predicate on the "specialty" field.
+func SpecialtyHasPrefix(v string) predicate.Character {
+	return predicate.Character(sql.FieldHasPrefix(FieldSpecialty, v))
+}
+
+// SpecialtyHasSuffix applies the HasSuffix predicate on the "specialty" field.
+func SpecialtyHasSuffix(v string) predicate.Character {
+	return predicate.Character(sql.FieldHasSuffix(FieldSpecialty, v))
+}
+
+// SpecialtyIsNil applies the IsNil predicate on the "specialty" field.
+func SpecialtyIsNil() predicate.Character {
+	return predicate.Character(sql.FieldIsNull(FieldSpecialty))
+}
+
+// SpecialtyNotNil applies the NotNil predicate on the "specialty" field.
+func SpecialtyNotNil() predicate.Character {
+	return predicate.Character(sql.FieldNotNull(FieldSpecialty))
+}
+
+// SpecialtyEqualFold applies the EqualFold predicate on the "specialty" field.
+func SpecialtyEqualFold(v string) predicate.Character {
+	return predicate.Character(sql.FieldEqualFold(FieldSpecialty, v))
+}
+
+// SpecialtyContainsFold applies the ContainsFold predicate on the "specialty" field.
+func SpecialtyContainsFold(v string) predicate.Character {
+	return predicate.Character(sql.FieldContainsFold(FieldSpecialty, v))
 }
 
 // LevelEQ applies the EQ predicate on the "level" field.
@@ -1610,6 +1690,75 @@ func HasNpcTemplate() predicate.Character {
 func HasNpcTemplateWith(preds ...predicate.NPCTemplate) predicate.Character {
 	return predicate.Character(func(s *sql.Selector) {
 		step := newNpcTemplateStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasAvailableTalents applies the HasEdge predicate on the "available_talents" edge.
+func HasAvailableTalents() predicate.Character {
+	return predicate.Character(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, AvailableTalentsTable, AvailableTalentsPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasAvailableTalentsWith applies the HasEdge predicate on the "available_talents" edge with a given conditions (other predicates).
+func HasAvailableTalentsWith(preds ...predicate.AvailableTalent) predicate.Character {
+	return predicate.Character(func(s *sql.Selector) {
+		step := newAvailableTalentsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasSkills applies the HasEdge predicate on the "skills" edge.
+func HasSkills() predicate.Character {
+	return predicate.Character(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, SkillsTable, SkillsColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasSkillsWith applies the HasEdge predicate on the "skills" edge with a given conditions (other predicates).
+func HasSkillsWith(preds ...predicate.CharacterSkill) predicate.Character {
+	return predicate.Character(func(s *sql.Selector) {
+		step := newSkillsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasTalents applies the HasEdge predicate on the "talents" edge.
+func HasTalents() predicate.Character {
+	return predicate.Character(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, TalentsTable, TalentsColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasTalentsWith applies the HasEdge predicate on the "talents" edge with a given conditions (other predicates).
+func HasTalentsWith(preds ...predicate.CharacterTalent) predicate.Character {
+	return predicate.Character(func(s *sql.Selector) {
+		step := newTalentsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/server/db/character_create.go
+++ b/server/db/character_create.go
@@ -6,7 +6,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"herbst-server/db/availabletalent"
 	"herbst-server/db/character"
+	"herbst-server/db/characterskill"
+	"herbst-server/db/charactertalent"
 	"herbst-server/db/npctemplate"
 	"herbst-server/db/room"
 	"herbst-server/db/user"
@@ -190,6 +193,20 @@ func (_c *CharacterCreate) SetClass(v string) *CharacterCreate {
 func (_c *CharacterCreate) SetNillableClass(v *string) *CharacterCreate {
 	if v != nil {
 		_c.SetClass(*v)
+	}
+	return _c
+}
+
+// SetSpecialty sets the "specialty" field.
+func (_c *CharacterCreate) SetSpecialty(v string) *CharacterCreate {
+	_c.mutation.SetSpecialty(v)
+	return _c
+}
+
+// SetNillableSpecialty sets the "specialty" field if the given value is not nil.
+func (_c *CharacterCreate) SetNillableSpecialty(v *string) *CharacterCreate {
+	if v != nil {
+		_c.SetSpecialty(*v)
 	}
 	return _c
 }
@@ -479,6 +496,51 @@ func (_c *CharacterCreate) SetNillableNpcTemplateID(id *string) *CharacterCreate
 // SetNpcTemplate sets the "npcTemplate" edge to the NPCTemplate entity.
 func (_c *CharacterCreate) SetNpcTemplate(v *NPCTemplate) *CharacterCreate {
 	return _c.SetNpcTemplateID(v.ID)
+}
+
+// AddAvailableTalentIDs adds the "available_talents" edge to the AvailableTalent entity by IDs.
+func (_c *CharacterCreate) AddAvailableTalentIDs(ids ...int) *CharacterCreate {
+	_c.mutation.AddAvailableTalentIDs(ids...)
+	return _c
+}
+
+// AddAvailableTalents adds the "available_talents" edges to the AvailableTalent entity.
+func (_c *CharacterCreate) AddAvailableTalents(v ...*AvailableTalent) *CharacterCreate {
+	ids := make([]int, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _c.AddAvailableTalentIDs(ids...)
+}
+
+// AddSkillIDs adds the "skills" edge to the CharacterSkill entity by IDs.
+func (_c *CharacterCreate) AddSkillIDs(ids ...int) *CharacterCreate {
+	_c.mutation.AddSkillIDs(ids...)
+	return _c
+}
+
+// AddSkills adds the "skills" edges to the CharacterSkill entity.
+func (_c *CharacterCreate) AddSkills(v ...*CharacterSkill) *CharacterCreate {
+	ids := make([]int, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _c.AddSkillIDs(ids...)
+}
+
+// AddTalentIDs adds the "talents" edge to the CharacterTalent entity by IDs.
+func (_c *CharacterCreate) AddTalentIDs(ids ...int) *CharacterCreate {
+	_c.mutation.AddTalentIDs(ids...)
+	return _c
+}
+
+// AddTalents adds the "talents" edges to the CharacterTalent entity.
+func (_c *CharacterCreate) AddTalents(v ...*CharacterTalent) *CharacterCreate {
+	ids := make([]int, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _c.AddTalentIDs(ids...)
 }
 
 // Mutation returns the CharacterMutation object of the builder.
@@ -785,6 +847,10 @@ func (_c *CharacterCreate) createSpec() (*Character, *sqlgraph.CreateSpec) {
 		_spec.SetField(character.FieldClass, field.TypeString, value)
 		_node.Class = value
 	}
+	if value, ok := _c.mutation.Specialty(); ok {
+		_spec.SetField(character.FieldSpecialty, field.TypeString, value)
+		_node.Specialty = value
+	}
 	if value, ok := _c.mutation.Level(); ok {
 		_spec.SetField(character.FieldLevel, field.TypeInt, value)
 		_node.Level = value
@@ -902,6 +968,54 @@ func (_c *CharacterCreate) createSpec() (*Character, *sqlgraph.CreateSpec) {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.character_npc_template = &nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.AvailableTalentsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   character.AvailableTalentsTable,
+			Columns: character.AvailableTalentsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(availabletalent.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.SkillsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   character.SkillsTable,
+			Columns: []string{character.SkillsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(characterskill.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.TalentsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   character.TalentsTable,
+			Columns: []string{character.TalentsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(charactertalent.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/server/db/character_query.go
+++ b/server/db/character_query.go
@@ -4,8 +4,12 @@ package db
 
 import (
 	"context"
+	"database/sql/driver"
 	"fmt"
+	"herbst-server/db/availabletalent"
 	"herbst-server/db/character"
+	"herbst-server/db/characterskill"
+	"herbst-server/db/charactertalent"
 	"herbst-server/db/npctemplate"
 	"herbst-server/db/predicate"
 	"herbst-server/db/room"
@@ -21,14 +25,17 @@ import (
 // CharacterQuery is the builder for querying Character entities.
 type CharacterQuery struct {
 	config
-	ctx             *QueryContext
-	order           []character.OrderOption
-	inters          []Interceptor
-	predicates      []predicate.Character
-	withUser        *UserQuery
-	withRoom        *RoomQuery
-	withNpcTemplate *NPCTemplateQuery
-	withFKs         bool
+	ctx                  *QueryContext
+	order                []character.OrderOption
+	inters               []Interceptor
+	predicates           []predicate.Character
+	withUser             *UserQuery
+	withRoom             *RoomQuery
+	withNpcTemplate      *NPCTemplateQuery
+	withAvailableTalents *AvailableTalentQuery
+	withSkills           *CharacterSkillQuery
+	withTalents          *CharacterTalentQuery
+	withFKs              bool
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
 	path func(context.Context) (*sql.Selector, error)
@@ -124,6 +131,72 @@ func (_q *CharacterQuery) QueryNpcTemplate() *NPCTemplateQuery {
 			sqlgraph.From(character.Table, character.FieldID, selector),
 			sqlgraph.To(npctemplate.Table, npctemplate.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, false, character.NpcTemplateTable, character.NpcTemplateColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryAvailableTalents chains the current query on the "available_talents" edge.
+func (_q *CharacterQuery) QueryAvailableTalents() *AvailableTalentQuery {
+	query := (&AvailableTalentClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(character.Table, character.FieldID, selector),
+			sqlgraph.To(availabletalent.Table, availabletalent.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, character.AvailableTalentsTable, character.AvailableTalentsPrimaryKey...),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QuerySkills chains the current query on the "skills" edge.
+func (_q *CharacterQuery) QuerySkills() *CharacterSkillQuery {
+	query := (&CharacterSkillClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(character.Table, character.FieldID, selector),
+			sqlgraph.To(characterskill.Table, characterskill.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, character.SkillsTable, character.SkillsColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryTalents chains the current query on the "talents" edge.
+func (_q *CharacterQuery) QueryTalents() *CharacterTalentQuery {
+	query := (&CharacterTalentClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(character.Table, character.FieldID, selector),
+			sqlgraph.To(charactertalent.Table, charactertalent.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, character.TalentsTable, character.TalentsColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -318,14 +391,17 @@ func (_q *CharacterQuery) Clone() *CharacterQuery {
 		return nil
 	}
 	return &CharacterQuery{
-		config:          _q.config,
-		ctx:             _q.ctx.Clone(),
-		order:           append([]character.OrderOption{}, _q.order...),
-		inters:          append([]Interceptor{}, _q.inters...),
-		predicates:      append([]predicate.Character{}, _q.predicates...),
-		withUser:        _q.withUser.Clone(),
-		withRoom:        _q.withRoom.Clone(),
-		withNpcTemplate: _q.withNpcTemplate.Clone(),
+		config:               _q.config,
+		ctx:                  _q.ctx.Clone(),
+		order:                append([]character.OrderOption{}, _q.order...),
+		inters:               append([]Interceptor{}, _q.inters...),
+		predicates:           append([]predicate.Character{}, _q.predicates...),
+		withUser:             _q.withUser.Clone(),
+		withRoom:             _q.withRoom.Clone(),
+		withNpcTemplate:      _q.withNpcTemplate.Clone(),
+		withAvailableTalents: _q.withAvailableTalents.Clone(),
+		withSkills:           _q.withSkills.Clone(),
+		withTalents:          _q.withTalents.Clone(),
 		// clone intermediate query.
 		sql:  _q.sql.Clone(),
 		path: _q.path,
@@ -362,6 +438,39 @@ func (_q *CharacterQuery) WithNpcTemplate(opts ...func(*NPCTemplateQuery)) *Char
 		opt(query)
 	}
 	_q.withNpcTemplate = query
+	return _q
+}
+
+// WithAvailableTalents tells the query-builder to eager-load the nodes that are connected to
+// the "available_talents" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *CharacterQuery) WithAvailableTalents(opts ...func(*AvailableTalentQuery)) *CharacterQuery {
+	query := (&AvailableTalentClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withAvailableTalents = query
+	return _q
+}
+
+// WithSkills tells the query-builder to eager-load the nodes that are connected to
+// the "skills" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *CharacterQuery) WithSkills(opts ...func(*CharacterSkillQuery)) *CharacterQuery {
+	query := (&CharacterSkillClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withSkills = query
+	return _q
+}
+
+// WithTalents tells the query-builder to eager-load the nodes that are connected to
+// the "talents" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *CharacterQuery) WithTalents(opts ...func(*CharacterTalentQuery)) *CharacterQuery {
+	query := (&CharacterTalentClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withTalents = query
 	return _q
 }
 
@@ -444,10 +553,13 @@ func (_q *CharacterQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Ch
 		nodes       = []*Character{}
 		withFKs     = _q.withFKs
 		_spec       = _q.querySpec()
-		loadedTypes = [3]bool{
+		loadedTypes = [6]bool{
 			_q.withUser != nil,
 			_q.withRoom != nil,
 			_q.withNpcTemplate != nil,
+			_q.withAvailableTalents != nil,
+			_q.withSkills != nil,
+			_q.withTalents != nil,
 		}
 	)
 	if _q.withUser != nil || _q.withNpcTemplate != nil {
@@ -489,6 +601,27 @@ func (_q *CharacterQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Ch
 	if query := _q.withNpcTemplate; query != nil {
 		if err := _q.loadNpcTemplate(ctx, query, nodes, nil,
 			func(n *Character, e *NPCTemplate) { n.Edges.NpcTemplate = e }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withAvailableTalents; query != nil {
+		if err := _q.loadAvailableTalents(ctx, query, nodes,
+			func(n *Character) { n.Edges.AvailableTalents = []*AvailableTalent{} },
+			func(n *Character, e *AvailableTalent) { n.Edges.AvailableTalents = append(n.Edges.AvailableTalents, e) }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withSkills; query != nil {
+		if err := _q.loadSkills(ctx, query, nodes,
+			func(n *Character) { n.Edges.Skills = []*CharacterSkill{} },
+			func(n *Character, e *CharacterSkill) { n.Edges.Skills = append(n.Edges.Skills, e) }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withTalents; query != nil {
+		if err := _q.loadTalents(ctx, query, nodes,
+			func(n *Character) { n.Edges.Talents = []*CharacterTalent{} },
+			func(n *Character, e *CharacterTalent) { n.Edges.Talents = append(n.Edges.Talents, e) }); err != nil {
 			return nil, err
 		}
 	}
@@ -585,6 +718,129 @@ func (_q *CharacterQuery) loadNpcTemplate(ctx context.Context, query *NPCTemplat
 		for i := range nodes {
 			assign(nodes[i], n)
 		}
+	}
+	return nil
+}
+func (_q *CharacterQuery) loadAvailableTalents(ctx context.Context, query *AvailableTalentQuery, nodes []*Character, init func(*Character), assign func(*Character, *AvailableTalent)) error {
+	edgeIDs := make([]driver.Value, len(nodes))
+	byID := make(map[int]*Character)
+	nids := make(map[int]map[*Character]struct{})
+	for i, node := range nodes {
+		edgeIDs[i] = node.ID
+		byID[node.ID] = node
+		if init != nil {
+			init(node)
+		}
+	}
+	query.Where(func(s *sql.Selector) {
+		joinT := sql.Table(character.AvailableTalentsTable)
+		s.Join(joinT).On(s.C(availabletalent.FieldID), joinT.C(character.AvailableTalentsPrimaryKey[1]))
+		s.Where(sql.InValues(joinT.C(character.AvailableTalentsPrimaryKey[0]), edgeIDs...))
+		columns := s.SelectedColumns()
+		s.Select(joinT.C(character.AvailableTalentsPrimaryKey[0]))
+		s.AppendSelect(columns...)
+		s.SetDistinct(false)
+	})
+	if err := query.prepareQuery(ctx); err != nil {
+		return err
+	}
+	qr := QuerierFunc(func(ctx context.Context, q Query) (Value, error) {
+		return query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
+			assign := spec.Assign
+			values := spec.ScanValues
+			spec.ScanValues = func(columns []string) ([]any, error) {
+				values, err := values(columns[1:])
+				if err != nil {
+					return nil, err
+				}
+				return append([]any{new(sql.NullInt64)}, values...), nil
+			}
+			spec.Assign = func(columns []string, values []any) error {
+				outValue := int(values[0].(*sql.NullInt64).Int64)
+				inValue := int(values[1].(*sql.NullInt64).Int64)
+				if nids[inValue] == nil {
+					nids[inValue] = map[*Character]struct{}{byID[outValue]: {}}
+					return assign(columns[1:], values[1:])
+				}
+				nids[inValue][byID[outValue]] = struct{}{}
+				return nil
+			}
+		})
+	})
+	neighbors, err := withInterceptors[[]*AvailableTalent](ctx, query, qr, query.inters)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected "available_talents" node returned %v`, n.ID)
+		}
+		for kn := range nodes {
+			assign(kn, n)
+		}
+	}
+	return nil
+}
+func (_q *CharacterQuery) loadSkills(ctx context.Context, query *CharacterSkillQuery, nodes []*Character, init func(*Character), assign func(*Character, *CharacterSkill)) error {
+	fks := make([]driver.Value, 0, len(nodes))
+	nodeids := make(map[int]*Character)
+	for i := range nodes {
+		fks = append(fks, nodes[i].ID)
+		nodeids[nodes[i].ID] = nodes[i]
+		if init != nil {
+			init(nodes[i])
+		}
+	}
+	query.withFKs = true
+	query.Where(predicate.CharacterSkill(func(s *sql.Selector) {
+		s.Where(sql.InValues(s.C(character.SkillsColumn), fks...))
+	}))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		fk := n.character_skills
+		if fk == nil {
+			return fmt.Errorf(`foreign-key "character_skills" is nil for node %v`, n.ID)
+		}
+		node, ok := nodeids[*fk]
+		if !ok {
+			return fmt.Errorf(`unexpected referenced foreign-key "character_skills" returned %v for node %v`, *fk, n.ID)
+		}
+		assign(node, n)
+	}
+	return nil
+}
+func (_q *CharacterQuery) loadTalents(ctx context.Context, query *CharacterTalentQuery, nodes []*Character, init func(*Character), assign func(*Character, *CharacterTalent)) error {
+	fks := make([]driver.Value, 0, len(nodes))
+	nodeids := make(map[int]*Character)
+	for i := range nodes {
+		fks = append(fks, nodes[i].ID)
+		nodeids[nodes[i].ID] = nodes[i]
+		if init != nil {
+			init(nodes[i])
+		}
+	}
+	query.withFKs = true
+	query.Where(predicate.CharacterTalent(func(s *sql.Selector) {
+		s.Where(sql.InValues(s.C(character.TalentsColumn), fks...))
+	}))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		fk := n.character_talents
+		if fk == nil {
+			return fmt.Errorf(`foreign-key "character_talents" is nil for node %v`, n.ID)
+		}
+		node, ok := nodeids[*fk]
+		if !ok {
+			return fmt.Errorf(`unexpected referenced foreign-key "character_talents" returned %v for node %v`, *fk, n.ID)
+		}
+		assign(node, n)
 	}
 	return nil
 }

--- a/server/db/character_update.go
+++ b/server/db/character_update.go
@@ -6,7 +6,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"herbst-server/db/availabletalent"
 	"herbst-server/db/character"
+	"herbst-server/db/characterskill"
+	"herbst-server/db/charactertalent"
 	"herbst-server/db/npctemplate"
 	"herbst-server/db/predicate"
 	"herbst-server/db/room"
@@ -278,6 +281,26 @@ func (_u *CharacterUpdate) SetNillableClass(v *string) *CharacterUpdate {
 	if v != nil {
 		_u.SetClass(*v)
 	}
+	return _u
+}
+
+// SetSpecialty sets the "specialty" field.
+func (_u *CharacterUpdate) SetSpecialty(v string) *CharacterUpdate {
+	_u.mutation.SetSpecialty(v)
+	return _u
+}
+
+// SetNillableSpecialty sets the "specialty" field if the given value is not nil.
+func (_u *CharacterUpdate) SetNillableSpecialty(v *string) *CharacterUpdate {
+	if v != nil {
+		_u.SetSpecialty(*v)
+	}
+	return _u
+}
+
+// ClearSpecialty clears the value of the "specialty" field.
+func (_u *CharacterUpdate) ClearSpecialty() *CharacterUpdate {
+	_u.mutation.ClearSpecialty()
 	return _u
 }
 
@@ -685,6 +708,51 @@ func (_u *CharacterUpdate) SetNpcTemplate(v *NPCTemplate) *CharacterUpdate {
 	return _u.SetNpcTemplateID(v.ID)
 }
 
+// AddAvailableTalentIDs adds the "available_talents" edge to the AvailableTalent entity by IDs.
+func (_u *CharacterUpdate) AddAvailableTalentIDs(ids ...int) *CharacterUpdate {
+	_u.mutation.AddAvailableTalentIDs(ids...)
+	return _u
+}
+
+// AddAvailableTalents adds the "available_talents" edges to the AvailableTalent entity.
+func (_u *CharacterUpdate) AddAvailableTalents(v ...*AvailableTalent) *CharacterUpdate {
+	ids := make([]int, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddAvailableTalentIDs(ids...)
+}
+
+// AddSkillIDs adds the "skills" edge to the CharacterSkill entity by IDs.
+func (_u *CharacterUpdate) AddSkillIDs(ids ...int) *CharacterUpdate {
+	_u.mutation.AddSkillIDs(ids...)
+	return _u
+}
+
+// AddSkills adds the "skills" edges to the CharacterSkill entity.
+func (_u *CharacterUpdate) AddSkills(v ...*CharacterSkill) *CharacterUpdate {
+	ids := make([]int, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddSkillIDs(ids...)
+}
+
+// AddTalentIDs adds the "talents" edge to the CharacterTalent entity by IDs.
+func (_u *CharacterUpdate) AddTalentIDs(ids ...int) *CharacterUpdate {
+	_u.mutation.AddTalentIDs(ids...)
+	return _u
+}
+
+// AddTalents adds the "talents" edges to the CharacterTalent entity.
+func (_u *CharacterUpdate) AddTalents(v ...*CharacterTalent) *CharacterUpdate {
+	ids := make([]int, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddTalentIDs(ids...)
+}
+
 // Mutation returns the CharacterMutation object of the builder.
 func (_u *CharacterUpdate) Mutation() *CharacterMutation {
 	return _u.mutation
@@ -706,6 +774,69 @@ func (_u *CharacterUpdate) ClearRoom() *CharacterUpdate {
 func (_u *CharacterUpdate) ClearNpcTemplate() *CharacterUpdate {
 	_u.mutation.ClearNpcTemplate()
 	return _u
+}
+
+// ClearAvailableTalents clears all "available_talents" edges to the AvailableTalent entity.
+func (_u *CharacterUpdate) ClearAvailableTalents() *CharacterUpdate {
+	_u.mutation.ClearAvailableTalents()
+	return _u
+}
+
+// RemoveAvailableTalentIDs removes the "available_talents" edge to AvailableTalent entities by IDs.
+func (_u *CharacterUpdate) RemoveAvailableTalentIDs(ids ...int) *CharacterUpdate {
+	_u.mutation.RemoveAvailableTalentIDs(ids...)
+	return _u
+}
+
+// RemoveAvailableTalents removes "available_talents" edges to AvailableTalent entities.
+func (_u *CharacterUpdate) RemoveAvailableTalents(v ...*AvailableTalent) *CharacterUpdate {
+	ids := make([]int, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveAvailableTalentIDs(ids...)
+}
+
+// ClearSkills clears all "skills" edges to the CharacterSkill entity.
+func (_u *CharacterUpdate) ClearSkills() *CharacterUpdate {
+	_u.mutation.ClearSkills()
+	return _u
+}
+
+// RemoveSkillIDs removes the "skills" edge to CharacterSkill entities by IDs.
+func (_u *CharacterUpdate) RemoveSkillIDs(ids ...int) *CharacterUpdate {
+	_u.mutation.RemoveSkillIDs(ids...)
+	return _u
+}
+
+// RemoveSkills removes "skills" edges to CharacterSkill entities.
+func (_u *CharacterUpdate) RemoveSkills(v ...*CharacterSkill) *CharacterUpdate {
+	ids := make([]int, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveSkillIDs(ids...)
+}
+
+// ClearTalents clears all "talents" edges to the CharacterTalent entity.
+func (_u *CharacterUpdate) ClearTalents() *CharacterUpdate {
+	_u.mutation.ClearTalents()
+	return _u
+}
+
+// RemoveTalentIDs removes the "talents" edge to CharacterTalent entities by IDs.
+func (_u *CharacterUpdate) RemoveTalentIDs(ids ...int) *CharacterUpdate {
+	_u.mutation.RemoveTalentIDs(ids...)
+	return _u
+}
+
+// RemoveTalents removes "talents" edges to CharacterTalent entities.
+func (_u *CharacterUpdate) RemoveTalents(v ...*CharacterTalent) *CharacterUpdate {
+	ids := make([]int, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveTalentIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -817,6 +948,12 @@ func (_u *CharacterUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.Class(); ok {
 		_spec.SetField(character.FieldClass, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.Specialty(); ok {
+		_spec.SetField(character.FieldSpecialty, field.TypeString, value)
+	}
+	if _u.mutation.SpecialtyCleared() {
+		_spec.ClearField(character.FieldSpecialty, field.TypeString)
 	}
 	if value, ok := _u.mutation.Level(); ok {
 		_spec.SetField(character.FieldLevel, field.TypeInt, value)
@@ -1000,6 +1137,141 @@ func (_u *CharacterUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(npctemplate.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.AvailableTalentsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   character.AvailableTalentsTable,
+			Columns: character.AvailableTalentsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(availabletalent.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedAvailableTalentsIDs(); len(nodes) > 0 && !_u.mutation.AvailableTalentsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   character.AvailableTalentsTable,
+			Columns: character.AvailableTalentsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(availabletalent.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.AvailableTalentsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   character.AvailableTalentsTable,
+			Columns: character.AvailableTalentsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(availabletalent.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.SkillsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   character.SkillsTable,
+			Columns: []string{character.SkillsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(characterskill.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedSkillsIDs(); len(nodes) > 0 && !_u.mutation.SkillsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   character.SkillsTable,
+			Columns: []string{character.SkillsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(characterskill.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.SkillsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   character.SkillsTable,
+			Columns: []string{character.SkillsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(characterskill.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.TalentsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   character.TalentsTable,
+			Columns: []string{character.TalentsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(charactertalent.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedTalentsIDs(); len(nodes) > 0 && !_u.mutation.TalentsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   character.TalentsTable,
+			Columns: []string{character.TalentsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(charactertalent.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.TalentsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   character.TalentsTable,
+			Columns: []string{character.TalentsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(charactertalent.FieldID, field.TypeInt),
 			},
 		}
 		for _, k := range nodes {
@@ -1275,6 +1547,26 @@ func (_u *CharacterUpdateOne) SetNillableClass(v *string) *CharacterUpdateOne {
 	if v != nil {
 		_u.SetClass(*v)
 	}
+	return _u
+}
+
+// SetSpecialty sets the "specialty" field.
+func (_u *CharacterUpdateOne) SetSpecialty(v string) *CharacterUpdateOne {
+	_u.mutation.SetSpecialty(v)
+	return _u
+}
+
+// SetNillableSpecialty sets the "specialty" field if the given value is not nil.
+func (_u *CharacterUpdateOne) SetNillableSpecialty(v *string) *CharacterUpdateOne {
+	if v != nil {
+		_u.SetSpecialty(*v)
+	}
+	return _u
+}
+
+// ClearSpecialty clears the value of the "specialty" field.
+func (_u *CharacterUpdateOne) ClearSpecialty() *CharacterUpdateOne {
+	_u.mutation.ClearSpecialty()
 	return _u
 }
 
@@ -1682,6 +1974,51 @@ func (_u *CharacterUpdateOne) SetNpcTemplate(v *NPCTemplate) *CharacterUpdateOne
 	return _u.SetNpcTemplateID(v.ID)
 }
 
+// AddAvailableTalentIDs adds the "available_talents" edge to the AvailableTalent entity by IDs.
+func (_u *CharacterUpdateOne) AddAvailableTalentIDs(ids ...int) *CharacterUpdateOne {
+	_u.mutation.AddAvailableTalentIDs(ids...)
+	return _u
+}
+
+// AddAvailableTalents adds the "available_talents" edges to the AvailableTalent entity.
+func (_u *CharacterUpdateOne) AddAvailableTalents(v ...*AvailableTalent) *CharacterUpdateOne {
+	ids := make([]int, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddAvailableTalentIDs(ids...)
+}
+
+// AddSkillIDs adds the "skills" edge to the CharacterSkill entity by IDs.
+func (_u *CharacterUpdateOne) AddSkillIDs(ids ...int) *CharacterUpdateOne {
+	_u.mutation.AddSkillIDs(ids...)
+	return _u
+}
+
+// AddSkills adds the "skills" edges to the CharacterSkill entity.
+func (_u *CharacterUpdateOne) AddSkills(v ...*CharacterSkill) *CharacterUpdateOne {
+	ids := make([]int, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddSkillIDs(ids...)
+}
+
+// AddTalentIDs adds the "talents" edge to the CharacterTalent entity by IDs.
+func (_u *CharacterUpdateOne) AddTalentIDs(ids ...int) *CharacterUpdateOne {
+	_u.mutation.AddTalentIDs(ids...)
+	return _u
+}
+
+// AddTalents adds the "talents" edges to the CharacterTalent entity.
+func (_u *CharacterUpdateOne) AddTalents(v ...*CharacterTalent) *CharacterUpdateOne {
+	ids := make([]int, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddTalentIDs(ids...)
+}
+
 // Mutation returns the CharacterMutation object of the builder.
 func (_u *CharacterUpdateOne) Mutation() *CharacterMutation {
 	return _u.mutation
@@ -1703,6 +2040,69 @@ func (_u *CharacterUpdateOne) ClearRoom() *CharacterUpdateOne {
 func (_u *CharacterUpdateOne) ClearNpcTemplate() *CharacterUpdateOne {
 	_u.mutation.ClearNpcTemplate()
 	return _u
+}
+
+// ClearAvailableTalents clears all "available_talents" edges to the AvailableTalent entity.
+func (_u *CharacterUpdateOne) ClearAvailableTalents() *CharacterUpdateOne {
+	_u.mutation.ClearAvailableTalents()
+	return _u
+}
+
+// RemoveAvailableTalentIDs removes the "available_talents" edge to AvailableTalent entities by IDs.
+func (_u *CharacterUpdateOne) RemoveAvailableTalentIDs(ids ...int) *CharacterUpdateOne {
+	_u.mutation.RemoveAvailableTalentIDs(ids...)
+	return _u
+}
+
+// RemoveAvailableTalents removes "available_talents" edges to AvailableTalent entities.
+func (_u *CharacterUpdateOne) RemoveAvailableTalents(v ...*AvailableTalent) *CharacterUpdateOne {
+	ids := make([]int, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveAvailableTalentIDs(ids...)
+}
+
+// ClearSkills clears all "skills" edges to the CharacterSkill entity.
+func (_u *CharacterUpdateOne) ClearSkills() *CharacterUpdateOne {
+	_u.mutation.ClearSkills()
+	return _u
+}
+
+// RemoveSkillIDs removes the "skills" edge to CharacterSkill entities by IDs.
+func (_u *CharacterUpdateOne) RemoveSkillIDs(ids ...int) *CharacterUpdateOne {
+	_u.mutation.RemoveSkillIDs(ids...)
+	return _u
+}
+
+// RemoveSkills removes "skills" edges to CharacterSkill entities.
+func (_u *CharacterUpdateOne) RemoveSkills(v ...*CharacterSkill) *CharacterUpdateOne {
+	ids := make([]int, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveSkillIDs(ids...)
+}
+
+// ClearTalents clears all "talents" edges to the CharacterTalent entity.
+func (_u *CharacterUpdateOne) ClearTalents() *CharacterUpdateOne {
+	_u.mutation.ClearTalents()
+	return _u
+}
+
+// RemoveTalentIDs removes the "talents" edge to CharacterTalent entities by IDs.
+func (_u *CharacterUpdateOne) RemoveTalentIDs(ids ...int) *CharacterUpdateOne {
+	_u.mutation.RemoveTalentIDs(ids...)
+	return _u
+}
+
+// RemoveTalents removes "talents" edges to CharacterTalent entities.
+func (_u *CharacterUpdateOne) RemoveTalents(v ...*CharacterTalent) *CharacterUpdateOne {
+	ids := make([]int, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveTalentIDs(ids...)
 }
 
 // Where appends a list predicates to the CharacterUpdate builder.
@@ -1844,6 +2244,12 @@ func (_u *CharacterUpdateOne) sqlSave(ctx context.Context) (_node *Character, er
 	}
 	if value, ok := _u.mutation.Class(); ok {
 		_spec.SetField(character.FieldClass, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.Specialty(); ok {
+		_spec.SetField(character.FieldSpecialty, field.TypeString, value)
+	}
+	if _u.mutation.SpecialtyCleared() {
+		_spec.ClearField(character.FieldSpecialty, field.TypeString)
 	}
 	if value, ok := _u.mutation.Level(); ok {
 		_spec.SetField(character.FieldLevel, field.TypeInt, value)
@@ -2027,6 +2433,141 @@ func (_u *CharacterUpdateOne) sqlSave(ctx context.Context) (_node *Character, er
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(npctemplate.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.AvailableTalentsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   character.AvailableTalentsTable,
+			Columns: character.AvailableTalentsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(availabletalent.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedAvailableTalentsIDs(); len(nodes) > 0 && !_u.mutation.AvailableTalentsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   character.AvailableTalentsTable,
+			Columns: character.AvailableTalentsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(availabletalent.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.AvailableTalentsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   character.AvailableTalentsTable,
+			Columns: character.AvailableTalentsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(availabletalent.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.SkillsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   character.SkillsTable,
+			Columns: []string{character.SkillsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(characterskill.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedSkillsIDs(); len(nodes) > 0 && !_u.mutation.SkillsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   character.SkillsTable,
+			Columns: []string{character.SkillsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(characterskill.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.SkillsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   character.SkillsTable,
+			Columns: []string{character.SkillsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(characterskill.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.TalentsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   character.TalentsTable,
+			Columns: []string{character.TalentsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(charactertalent.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedTalentsIDs(); len(nodes) > 0 && !_u.mutation.TalentsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   character.TalentsTable,
+			Columns: []string{character.TalentsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(charactertalent.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.TalentsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   character.TalentsTable,
+			Columns: []string{character.TalentsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(charactertalent.FieldID, field.TypeInt),
 			},
 		}
 		for _, k := range nodes {

--- a/server/db/client.go
+++ b/server/db/client.go
@@ -11,10 +11,15 @@ import (
 
 	"herbst-server/db/migrate"
 
+	"herbst-server/db/availabletalent"
 	"herbst-server/db/character"
+	"herbst-server/db/characterskill"
+	"herbst-server/db/charactertalent"
 	"herbst-server/db/equipment"
 	"herbst-server/db/npctemplate"
 	"herbst-server/db/room"
+	"herbst-server/db/skill"
+	"herbst-server/db/talent"
 	"herbst-server/db/user"
 
 	"entgo.io/ent"
@@ -28,14 +33,24 @@ type Client struct {
 	config
 	// Schema is the client for creating, migrating and dropping schema.
 	Schema *migrate.Schema
+	// AvailableTalent is the client for interacting with the AvailableTalent builders.
+	AvailableTalent *AvailableTalentClient
 	// Character is the client for interacting with the Character builders.
 	Character *CharacterClient
+	// CharacterSkill is the client for interacting with the CharacterSkill builders.
+	CharacterSkill *CharacterSkillClient
+	// CharacterTalent is the client for interacting with the CharacterTalent builders.
+	CharacterTalent *CharacterTalentClient
 	// Equipment is the client for interacting with the Equipment builders.
 	Equipment *EquipmentClient
 	// NPCTemplate is the client for interacting with the NPCTemplate builders.
 	NPCTemplate *NPCTemplateClient
 	// Room is the client for interacting with the Room builders.
 	Room *RoomClient
+	// Skill is the client for interacting with the Skill builders.
+	Skill *SkillClient
+	// Talent is the client for interacting with the Talent builders.
+	Talent *TalentClient
 	// User is the client for interacting with the User builders.
 	User *UserClient
 }
@@ -49,10 +64,15 @@ func NewClient(opts ...Option) *Client {
 
 func (c *Client) init() {
 	c.Schema = migrate.NewSchema(c.driver)
+	c.AvailableTalent = NewAvailableTalentClient(c.config)
 	c.Character = NewCharacterClient(c.config)
+	c.CharacterSkill = NewCharacterSkillClient(c.config)
+	c.CharacterTalent = NewCharacterTalentClient(c.config)
 	c.Equipment = NewEquipmentClient(c.config)
 	c.NPCTemplate = NewNPCTemplateClient(c.config)
 	c.Room = NewRoomClient(c.config)
+	c.Skill = NewSkillClient(c.config)
+	c.Talent = NewTalentClient(c.config)
 	c.User = NewUserClient(c.config)
 }
 
@@ -144,13 +164,18 @@ func (c *Client) Tx(ctx context.Context) (*Tx, error) {
 	cfg := c.config
 	cfg.driver = tx
 	return &Tx{
-		ctx:         ctx,
-		config:      cfg,
-		Character:   NewCharacterClient(cfg),
-		Equipment:   NewEquipmentClient(cfg),
-		NPCTemplate: NewNPCTemplateClient(cfg),
-		Room:        NewRoomClient(cfg),
-		User:        NewUserClient(cfg),
+		ctx:             ctx,
+		config:          cfg,
+		AvailableTalent: NewAvailableTalentClient(cfg),
+		Character:       NewCharacterClient(cfg),
+		CharacterSkill:  NewCharacterSkillClient(cfg),
+		CharacterTalent: NewCharacterTalentClient(cfg),
+		Equipment:       NewEquipmentClient(cfg),
+		NPCTemplate:     NewNPCTemplateClient(cfg),
+		Room:            NewRoomClient(cfg),
+		Skill:           NewSkillClient(cfg),
+		Talent:          NewTalentClient(cfg),
+		User:            NewUserClient(cfg),
 	}, nil
 }
 
@@ -168,20 +193,25 @@ func (c *Client) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) 
 	cfg := c.config
 	cfg.driver = &txDriver{tx: tx, drv: c.driver}
 	return &Tx{
-		ctx:         ctx,
-		config:      cfg,
-		Character:   NewCharacterClient(cfg),
-		Equipment:   NewEquipmentClient(cfg),
-		NPCTemplate: NewNPCTemplateClient(cfg),
-		Room:        NewRoomClient(cfg),
-		User:        NewUserClient(cfg),
+		ctx:             ctx,
+		config:          cfg,
+		AvailableTalent: NewAvailableTalentClient(cfg),
+		Character:       NewCharacterClient(cfg),
+		CharacterSkill:  NewCharacterSkillClient(cfg),
+		CharacterTalent: NewCharacterTalentClient(cfg),
+		Equipment:       NewEquipmentClient(cfg),
+		NPCTemplate:     NewNPCTemplateClient(cfg),
+		Room:            NewRoomClient(cfg),
+		Skill:           NewSkillClient(cfg),
+		Talent:          NewTalentClient(cfg),
+		User:            NewUserClient(cfg),
 	}, nil
 }
 
 // Debug returns a new debug-client. It's used to get verbose logging on specific operations.
 //
 //	client.Debug().
-//		Character.
+//		AvailableTalent.
 //		Query().
 //		Count(ctx)
 func (c *Client) Debug() *Client {
@@ -203,38 +233,215 @@ func (c *Client) Close() error {
 // Use adds the mutation hooks to all the entity clients.
 // In order to add hooks to a specific client, call: `client.Node.Use(...)`.
 func (c *Client) Use(hooks ...Hook) {
-	c.Character.Use(hooks...)
-	c.Equipment.Use(hooks...)
-	c.NPCTemplate.Use(hooks...)
-	c.Room.Use(hooks...)
-	c.User.Use(hooks...)
+	for _, n := range []interface{ Use(...Hook) }{
+		c.AvailableTalent, c.Character, c.CharacterSkill, c.CharacterTalent,
+		c.Equipment, c.NPCTemplate, c.Room, c.Skill, c.Talent, c.User,
+	} {
+		n.Use(hooks...)
+	}
 }
 
 // Intercept adds the query interceptors to all the entity clients.
 // In order to add interceptors to a specific client, call: `client.Node.Intercept(...)`.
 func (c *Client) Intercept(interceptors ...Interceptor) {
-	c.Character.Intercept(interceptors...)
-	c.Equipment.Intercept(interceptors...)
-	c.NPCTemplate.Intercept(interceptors...)
-	c.Room.Intercept(interceptors...)
-	c.User.Intercept(interceptors...)
+	for _, n := range []interface{ Intercept(...Interceptor) }{
+		c.AvailableTalent, c.Character, c.CharacterSkill, c.CharacterTalent,
+		c.Equipment, c.NPCTemplate, c.Room, c.Skill, c.Talent, c.User,
+	} {
+		n.Intercept(interceptors...)
+	}
 }
 
 // Mutate implements the ent.Mutator interface.
 func (c *Client) Mutate(ctx context.Context, m Mutation) (Value, error) {
 	switch m := m.(type) {
+	case *AvailableTalentMutation:
+		return c.AvailableTalent.mutate(ctx, m)
 	case *CharacterMutation:
 		return c.Character.mutate(ctx, m)
+	case *CharacterSkillMutation:
+		return c.CharacterSkill.mutate(ctx, m)
+	case *CharacterTalentMutation:
+		return c.CharacterTalent.mutate(ctx, m)
 	case *EquipmentMutation:
 		return c.Equipment.mutate(ctx, m)
 	case *NPCTemplateMutation:
 		return c.NPCTemplate.mutate(ctx, m)
 	case *RoomMutation:
 		return c.Room.mutate(ctx, m)
+	case *SkillMutation:
+		return c.Skill.mutate(ctx, m)
+	case *TalentMutation:
+		return c.Talent.mutate(ctx, m)
 	case *UserMutation:
 		return c.User.mutate(ctx, m)
 	default:
 		return nil, fmt.Errorf("db: unknown mutation type %T", m)
+	}
+}
+
+// AvailableTalentClient is a client for the AvailableTalent schema.
+type AvailableTalentClient struct {
+	config
+}
+
+// NewAvailableTalentClient returns a client for the AvailableTalent from the given config.
+func NewAvailableTalentClient(c config) *AvailableTalentClient {
+	return &AvailableTalentClient{config: c}
+}
+
+// Use adds a list of mutation hooks to the hooks stack.
+// A call to `Use(f, g, h)` equals to `availabletalent.Hooks(f(g(h())))`.
+func (c *AvailableTalentClient) Use(hooks ...Hook) {
+	c.hooks.AvailableTalent = append(c.hooks.AvailableTalent, hooks...)
+}
+
+// Intercept adds a list of query interceptors to the interceptors stack.
+// A call to `Intercept(f, g, h)` equals to `availabletalent.Intercept(f(g(h())))`.
+func (c *AvailableTalentClient) Intercept(interceptors ...Interceptor) {
+	c.inters.AvailableTalent = append(c.inters.AvailableTalent, interceptors...)
+}
+
+// Create returns a builder for creating a AvailableTalent entity.
+func (c *AvailableTalentClient) Create() *AvailableTalentCreate {
+	mutation := newAvailableTalentMutation(c.config, OpCreate)
+	return &AvailableTalentCreate{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// CreateBulk returns a builder for creating a bulk of AvailableTalent entities.
+func (c *AvailableTalentClient) CreateBulk(builders ...*AvailableTalentCreate) *AvailableTalentCreateBulk {
+	return &AvailableTalentCreateBulk{config: c.config, builders: builders}
+}
+
+// MapCreateBulk creates a bulk creation builder from the given slice. For each item in the slice, the function creates
+// a builder and applies setFunc on it.
+func (c *AvailableTalentClient) MapCreateBulk(slice any, setFunc func(*AvailableTalentCreate, int)) *AvailableTalentCreateBulk {
+	rv := reflect.ValueOf(slice)
+	if rv.Kind() != reflect.Slice {
+		return &AvailableTalentCreateBulk{err: fmt.Errorf("calling to AvailableTalentClient.MapCreateBulk with wrong type %T, need slice", slice)}
+	}
+	builders := make([]*AvailableTalentCreate, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		builders[i] = c.Create()
+		setFunc(builders[i], i)
+	}
+	return &AvailableTalentCreateBulk{config: c.config, builders: builders}
+}
+
+// Update returns an update builder for AvailableTalent.
+func (c *AvailableTalentClient) Update() *AvailableTalentUpdate {
+	mutation := newAvailableTalentMutation(c.config, OpUpdate)
+	return &AvailableTalentUpdate{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// UpdateOne returns an update builder for the given entity.
+func (c *AvailableTalentClient) UpdateOne(_m *AvailableTalent) *AvailableTalentUpdateOne {
+	mutation := newAvailableTalentMutation(c.config, OpUpdateOne, withAvailableTalent(_m))
+	return &AvailableTalentUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// UpdateOneID returns an update builder for the given id.
+func (c *AvailableTalentClient) UpdateOneID(id int) *AvailableTalentUpdateOne {
+	mutation := newAvailableTalentMutation(c.config, OpUpdateOne, withAvailableTalentID(id))
+	return &AvailableTalentUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// Delete returns a delete builder for AvailableTalent.
+func (c *AvailableTalentClient) Delete() *AvailableTalentDelete {
+	mutation := newAvailableTalentMutation(c.config, OpDelete)
+	return &AvailableTalentDelete{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// DeleteOne returns a builder for deleting the given entity.
+func (c *AvailableTalentClient) DeleteOne(_m *AvailableTalent) *AvailableTalentDeleteOne {
+	return c.DeleteOneID(_m.ID)
+}
+
+// DeleteOneID returns a builder for deleting the given entity by its id.
+func (c *AvailableTalentClient) DeleteOneID(id int) *AvailableTalentDeleteOne {
+	builder := c.Delete().Where(availabletalent.ID(id))
+	builder.mutation.id = &id
+	builder.mutation.op = OpDeleteOne
+	return &AvailableTalentDeleteOne{builder}
+}
+
+// Query returns a query builder for AvailableTalent.
+func (c *AvailableTalentClient) Query() *AvailableTalentQuery {
+	return &AvailableTalentQuery{
+		config: c.config,
+		ctx:    &QueryContext{Type: TypeAvailableTalent},
+		inters: c.Interceptors(),
+	}
+}
+
+// Get returns a AvailableTalent entity by its id.
+func (c *AvailableTalentClient) Get(ctx context.Context, id int) (*AvailableTalent, error) {
+	return c.Query().Where(availabletalent.ID(id)).Only(ctx)
+}
+
+// GetX is like Get, but panics if an error occurs.
+func (c *AvailableTalentClient) GetX(ctx context.Context, id int) *AvailableTalent {
+	obj, err := c.Get(ctx, id)
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+// QueryCharacter queries the character edge of a AvailableTalent.
+func (c *AvailableTalentClient) QueryCharacter(_m *AvailableTalent) *CharacterQuery {
+	query := (&CharacterClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(availabletalent.Table, availabletalent.FieldID, id),
+			sqlgraph.To(character.Table, character.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, availabletalent.CharacterTable, availabletalent.CharacterPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryTalent queries the talent edge of a AvailableTalent.
+func (c *AvailableTalentClient) QueryTalent(_m *AvailableTalent) *TalentQuery {
+	query := (&TalentClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(availabletalent.Table, availabletalent.FieldID, id),
+			sqlgraph.To(talent.Table, talent.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, availabletalent.TalentTable, availabletalent.TalentPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// Hooks returns the client hooks.
+func (c *AvailableTalentClient) Hooks() []Hook {
+	return c.hooks.AvailableTalent
+}
+
+// Interceptors returns the client interceptors.
+func (c *AvailableTalentClient) Interceptors() []Interceptor {
+	return c.inters.AvailableTalent
+}
+
+func (c *AvailableTalentClient) mutate(ctx context.Context, m *AvailableTalentMutation) (Value, error) {
+	switch m.Op() {
+	case OpCreate:
+		return (&AvailableTalentCreate{config: c.config, hooks: c.Hooks(), mutation: m}).Save(ctx)
+	case OpUpdate:
+		return (&AvailableTalentUpdate{config: c.config, hooks: c.Hooks(), mutation: m}).Save(ctx)
+	case OpUpdateOne:
+		return (&AvailableTalentUpdateOne{config: c.config, hooks: c.Hooks(), mutation: m}).Save(ctx)
+	case OpDelete, OpDeleteOne:
+		return (&AvailableTalentDelete{config: c.config, hooks: c.Hooks(), mutation: m}).Exec(ctx)
+	default:
+		return nil, fmt.Errorf("db: unknown AvailableTalent mutation op: %q", m.Op())
 	}
 }
 
@@ -394,6 +601,54 @@ func (c *CharacterClient) QueryNpcTemplate(_m *Character) *NPCTemplateQuery {
 	return query
 }
 
+// QueryAvailableTalents queries the available_talents edge of a Character.
+func (c *CharacterClient) QueryAvailableTalents(_m *Character) *AvailableTalentQuery {
+	query := (&AvailableTalentClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(character.Table, character.FieldID, id),
+			sqlgraph.To(availabletalent.Table, availabletalent.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, character.AvailableTalentsTable, character.AvailableTalentsPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QuerySkills queries the skills edge of a Character.
+func (c *CharacterClient) QuerySkills(_m *Character) *CharacterSkillQuery {
+	query := (&CharacterSkillClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(character.Table, character.FieldID, id),
+			sqlgraph.To(characterskill.Table, characterskill.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, character.SkillsTable, character.SkillsColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryTalents queries the talents edge of a Character.
+func (c *CharacterClient) QueryTalents(_m *Character) *CharacterTalentQuery {
+	query := (&CharacterTalentClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(character.Table, character.FieldID, id),
+			sqlgraph.To(charactertalent.Table, charactertalent.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, character.TalentsTable, character.TalentsColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // Hooks returns the client hooks.
 func (c *CharacterClient) Hooks() []Hook {
 	return c.hooks.Character
@@ -416,6 +671,336 @@ func (c *CharacterClient) mutate(ctx context.Context, m *CharacterMutation) (Val
 		return (&CharacterDelete{config: c.config, hooks: c.Hooks(), mutation: m}).Exec(ctx)
 	default:
 		return nil, fmt.Errorf("db: unknown Character mutation op: %q", m.Op())
+	}
+}
+
+// CharacterSkillClient is a client for the CharacterSkill schema.
+type CharacterSkillClient struct {
+	config
+}
+
+// NewCharacterSkillClient returns a client for the CharacterSkill from the given config.
+func NewCharacterSkillClient(c config) *CharacterSkillClient {
+	return &CharacterSkillClient{config: c}
+}
+
+// Use adds a list of mutation hooks to the hooks stack.
+// A call to `Use(f, g, h)` equals to `characterskill.Hooks(f(g(h())))`.
+func (c *CharacterSkillClient) Use(hooks ...Hook) {
+	c.hooks.CharacterSkill = append(c.hooks.CharacterSkill, hooks...)
+}
+
+// Intercept adds a list of query interceptors to the interceptors stack.
+// A call to `Intercept(f, g, h)` equals to `characterskill.Intercept(f(g(h())))`.
+func (c *CharacterSkillClient) Intercept(interceptors ...Interceptor) {
+	c.inters.CharacterSkill = append(c.inters.CharacterSkill, interceptors...)
+}
+
+// Create returns a builder for creating a CharacterSkill entity.
+func (c *CharacterSkillClient) Create() *CharacterSkillCreate {
+	mutation := newCharacterSkillMutation(c.config, OpCreate)
+	return &CharacterSkillCreate{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// CreateBulk returns a builder for creating a bulk of CharacterSkill entities.
+func (c *CharacterSkillClient) CreateBulk(builders ...*CharacterSkillCreate) *CharacterSkillCreateBulk {
+	return &CharacterSkillCreateBulk{config: c.config, builders: builders}
+}
+
+// MapCreateBulk creates a bulk creation builder from the given slice. For each item in the slice, the function creates
+// a builder and applies setFunc on it.
+func (c *CharacterSkillClient) MapCreateBulk(slice any, setFunc func(*CharacterSkillCreate, int)) *CharacterSkillCreateBulk {
+	rv := reflect.ValueOf(slice)
+	if rv.Kind() != reflect.Slice {
+		return &CharacterSkillCreateBulk{err: fmt.Errorf("calling to CharacterSkillClient.MapCreateBulk with wrong type %T, need slice", slice)}
+	}
+	builders := make([]*CharacterSkillCreate, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		builders[i] = c.Create()
+		setFunc(builders[i], i)
+	}
+	return &CharacterSkillCreateBulk{config: c.config, builders: builders}
+}
+
+// Update returns an update builder for CharacterSkill.
+func (c *CharacterSkillClient) Update() *CharacterSkillUpdate {
+	mutation := newCharacterSkillMutation(c.config, OpUpdate)
+	return &CharacterSkillUpdate{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// UpdateOne returns an update builder for the given entity.
+func (c *CharacterSkillClient) UpdateOne(_m *CharacterSkill) *CharacterSkillUpdateOne {
+	mutation := newCharacterSkillMutation(c.config, OpUpdateOne, withCharacterSkill(_m))
+	return &CharacterSkillUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// UpdateOneID returns an update builder for the given id.
+func (c *CharacterSkillClient) UpdateOneID(id int) *CharacterSkillUpdateOne {
+	mutation := newCharacterSkillMutation(c.config, OpUpdateOne, withCharacterSkillID(id))
+	return &CharacterSkillUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// Delete returns a delete builder for CharacterSkill.
+func (c *CharacterSkillClient) Delete() *CharacterSkillDelete {
+	mutation := newCharacterSkillMutation(c.config, OpDelete)
+	return &CharacterSkillDelete{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// DeleteOne returns a builder for deleting the given entity.
+func (c *CharacterSkillClient) DeleteOne(_m *CharacterSkill) *CharacterSkillDeleteOne {
+	return c.DeleteOneID(_m.ID)
+}
+
+// DeleteOneID returns a builder for deleting the given entity by its id.
+func (c *CharacterSkillClient) DeleteOneID(id int) *CharacterSkillDeleteOne {
+	builder := c.Delete().Where(characterskill.ID(id))
+	builder.mutation.id = &id
+	builder.mutation.op = OpDeleteOne
+	return &CharacterSkillDeleteOne{builder}
+}
+
+// Query returns a query builder for CharacterSkill.
+func (c *CharacterSkillClient) Query() *CharacterSkillQuery {
+	return &CharacterSkillQuery{
+		config: c.config,
+		ctx:    &QueryContext{Type: TypeCharacterSkill},
+		inters: c.Interceptors(),
+	}
+}
+
+// Get returns a CharacterSkill entity by its id.
+func (c *CharacterSkillClient) Get(ctx context.Context, id int) (*CharacterSkill, error) {
+	return c.Query().Where(characterskill.ID(id)).Only(ctx)
+}
+
+// GetX is like Get, but panics if an error occurs.
+func (c *CharacterSkillClient) GetX(ctx context.Context, id int) *CharacterSkill {
+	obj, err := c.Get(ctx, id)
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+// QueryCharacter queries the character edge of a CharacterSkill.
+func (c *CharacterSkillClient) QueryCharacter(_m *CharacterSkill) *CharacterQuery {
+	query := (&CharacterClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(characterskill.Table, characterskill.FieldID, id),
+			sqlgraph.To(character.Table, character.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, characterskill.CharacterTable, characterskill.CharacterColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QuerySkill queries the skill edge of a CharacterSkill.
+func (c *CharacterSkillClient) QuerySkill(_m *CharacterSkill) *SkillQuery {
+	query := (&SkillClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(characterskill.Table, characterskill.FieldID, id),
+			sqlgraph.To(skill.Table, skill.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, characterskill.SkillTable, characterskill.SkillColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// Hooks returns the client hooks.
+func (c *CharacterSkillClient) Hooks() []Hook {
+	return c.hooks.CharacterSkill
+}
+
+// Interceptors returns the client interceptors.
+func (c *CharacterSkillClient) Interceptors() []Interceptor {
+	return c.inters.CharacterSkill
+}
+
+func (c *CharacterSkillClient) mutate(ctx context.Context, m *CharacterSkillMutation) (Value, error) {
+	switch m.Op() {
+	case OpCreate:
+		return (&CharacterSkillCreate{config: c.config, hooks: c.Hooks(), mutation: m}).Save(ctx)
+	case OpUpdate:
+		return (&CharacterSkillUpdate{config: c.config, hooks: c.Hooks(), mutation: m}).Save(ctx)
+	case OpUpdateOne:
+		return (&CharacterSkillUpdateOne{config: c.config, hooks: c.Hooks(), mutation: m}).Save(ctx)
+	case OpDelete, OpDeleteOne:
+		return (&CharacterSkillDelete{config: c.config, hooks: c.Hooks(), mutation: m}).Exec(ctx)
+	default:
+		return nil, fmt.Errorf("db: unknown CharacterSkill mutation op: %q", m.Op())
+	}
+}
+
+// CharacterTalentClient is a client for the CharacterTalent schema.
+type CharacterTalentClient struct {
+	config
+}
+
+// NewCharacterTalentClient returns a client for the CharacterTalent from the given config.
+func NewCharacterTalentClient(c config) *CharacterTalentClient {
+	return &CharacterTalentClient{config: c}
+}
+
+// Use adds a list of mutation hooks to the hooks stack.
+// A call to `Use(f, g, h)` equals to `charactertalent.Hooks(f(g(h())))`.
+func (c *CharacterTalentClient) Use(hooks ...Hook) {
+	c.hooks.CharacterTalent = append(c.hooks.CharacterTalent, hooks...)
+}
+
+// Intercept adds a list of query interceptors to the interceptors stack.
+// A call to `Intercept(f, g, h)` equals to `charactertalent.Intercept(f(g(h())))`.
+func (c *CharacterTalentClient) Intercept(interceptors ...Interceptor) {
+	c.inters.CharacterTalent = append(c.inters.CharacterTalent, interceptors...)
+}
+
+// Create returns a builder for creating a CharacterTalent entity.
+func (c *CharacterTalentClient) Create() *CharacterTalentCreate {
+	mutation := newCharacterTalentMutation(c.config, OpCreate)
+	return &CharacterTalentCreate{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// CreateBulk returns a builder for creating a bulk of CharacterTalent entities.
+func (c *CharacterTalentClient) CreateBulk(builders ...*CharacterTalentCreate) *CharacterTalentCreateBulk {
+	return &CharacterTalentCreateBulk{config: c.config, builders: builders}
+}
+
+// MapCreateBulk creates a bulk creation builder from the given slice. For each item in the slice, the function creates
+// a builder and applies setFunc on it.
+func (c *CharacterTalentClient) MapCreateBulk(slice any, setFunc func(*CharacterTalentCreate, int)) *CharacterTalentCreateBulk {
+	rv := reflect.ValueOf(slice)
+	if rv.Kind() != reflect.Slice {
+		return &CharacterTalentCreateBulk{err: fmt.Errorf("calling to CharacterTalentClient.MapCreateBulk with wrong type %T, need slice", slice)}
+	}
+	builders := make([]*CharacterTalentCreate, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		builders[i] = c.Create()
+		setFunc(builders[i], i)
+	}
+	return &CharacterTalentCreateBulk{config: c.config, builders: builders}
+}
+
+// Update returns an update builder for CharacterTalent.
+func (c *CharacterTalentClient) Update() *CharacterTalentUpdate {
+	mutation := newCharacterTalentMutation(c.config, OpUpdate)
+	return &CharacterTalentUpdate{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// UpdateOne returns an update builder for the given entity.
+func (c *CharacterTalentClient) UpdateOne(_m *CharacterTalent) *CharacterTalentUpdateOne {
+	mutation := newCharacterTalentMutation(c.config, OpUpdateOne, withCharacterTalent(_m))
+	return &CharacterTalentUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// UpdateOneID returns an update builder for the given id.
+func (c *CharacterTalentClient) UpdateOneID(id int) *CharacterTalentUpdateOne {
+	mutation := newCharacterTalentMutation(c.config, OpUpdateOne, withCharacterTalentID(id))
+	return &CharacterTalentUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// Delete returns a delete builder for CharacterTalent.
+func (c *CharacterTalentClient) Delete() *CharacterTalentDelete {
+	mutation := newCharacterTalentMutation(c.config, OpDelete)
+	return &CharacterTalentDelete{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// DeleteOne returns a builder for deleting the given entity.
+func (c *CharacterTalentClient) DeleteOne(_m *CharacterTalent) *CharacterTalentDeleteOne {
+	return c.DeleteOneID(_m.ID)
+}
+
+// DeleteOneID returns a builder for deleting the given entity by its id.
+func (c *CharacterTalentClient) DeleteOneID(id int) *CharacterTalentDeleteOne {
+	builder := c.Delete().Where(charactertalent.ID(id))
+	builder.mutation.id = &id
+	builder.mutation.op = OpDeleteOne
+	return &CharacterTalentDeleteOne{builder}
+}
+
+// Query returns a query builder for CharacterTalent.
+func (c *CharacterTalentClient) Query() *CharacterTalentQuery {
+	return &CharacterTalentQuery{
+		config: c.config,
+		ctx:    &QueryContext{Type: TypeCharacterTalent},
+		inters: c.Interceptors(),
+	}
+}
+
+// Get returns a CharacterTalent entity by its id.
+func (c *CharacterTalentClient) Get(ctx context.Context, id int) (*CharacterTalent, error) {
+	return c.Query().Where(charactertalent.ID(id)).Only(ctx)
+}
+
+// GetX is like Get, but panics if an error occurs.
+func (c *CharacterTalentClient) GetX(ctx context.Context, id int) *CharacterTalent {
+	obj, err := c.Get(ctx, id)
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+// QueryCharacter queries the character edge of a CharacterTalent.
+func (c *CharacterTalentClient) QueryCharacter(_m *CharacterTalent) *CharacterQuery {
+	query := (&CharacterClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(charactertalent.Table, charactertalent.FieldID, id),
+			sqlgraph.To(character.Table, character.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, charactertalent.CharacterTable, charactertalent.CharacterColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryTalent queries the talent edge of a CharacterTalent.
+func (c *CharacterTalentClient) QueryTalent(_m *CharacterTalent) *TalentQuery {
+	query := (&TalentClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(charactertalent.Table, charactertalent.FieldID, id),
+			sqlgraph.To(talent.Table, talent.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, charactertalent.TalentTable, charactertalent.TalentColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// Hooks returns the client hooks.
+func (c *CharacterTalentClient) Hooks() []Hook {
+	return c.hooks.CharacterTalent
+}
+
+// Interceptors returns the client interceptors.
+func (c *CharacterTalentClient) Interceptors() []Interceptor {
+	return c.inters.CharacterTalent
+}
+
+func (c *CharacterTalentClient) mutate(ctx context.Context, m *CharacterTalentMutation) (Value, error) {
+	switch m.Op() {
+	case OpCreate:
+		return (&CharacterTalentCreate{config: c.config, hooks: c.Hooks(), mutation: m}).Save(ctx)
+	case OpUpdate:
+		return (&CharacterTalentUpdate{config: c.config, hooks: c.Hooks(), mutation: m}).Save(ctx)
+	case OpUpdateOne:
+		return (&CharacterTalentUpdateOne{config: c.config, hooks: c.Hooks(), mutation: m}).Save(ctx)
+	case OpDelete, OpDeleteOne:
+		return (&CharacterTalentDelete{config: c.config, hooks: c.Hooks(), mutation: m}).Exec(ctx)
+	default:
+		return nil, fmt.Errorf("db: unknown CharacterTalent mutation op: %q", m.Op())
 	}
 }
 
@@ -866,6 +1451,320 @@ func (c *RoomClient) mutate(ctx context.Context, m *RoomMutation) (Value, error)
 	}
 }
 
+// SkillClient is a client for the Skill schema.
+type SkillClient struct {
+	config
+}
+
+// NewSkillClient returns a client for the Skill from the given config.
+func NewSkillClient(c config) *SkillClient {
+	return &SkillClient{config: c}
+}
+
+// Use adds a list of mutation hooks to the hooks stack.
+// A call to `Use(f, g, h)` equals to `skill.Hooks(f(g(h())))`.
+func (c *SkillClient) Use(hooks ...Hook) {
+	c.hooks.Skill = append(c.hooks.Skill, hooks...)
+}
+
+// Intercept adds a list of query interceptors to the interceptors stack.
+// A call to `Intercept(f, g, h)` equals to `skill.Intercept(f(g(h())))`.
+func (c *SkillClient) Intercept(interceptors ...Interceptor) {
+	c.inters.Skill = append(c.inters.Skill, interceptors...)
+}
+
+// Create returns a builder for creating a Skill entity.
+func (c *SkillClient) Create() *SkillCreate {
+	mutation := newSkillMutation(c.config, OpCreate)
+	return &SkillCreate{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// CreateBulk returns a builder for creating a bulk of Skill entities.
+func (c *SkillClient) CreateBulk(builders ...*SkillCreate) *SkillCreateBulk {
+	return &SkillCreateBulk{config: c.config, builders: builders}
+}
+
+// MapCreateBulk creates a bulk creation builder from the given slice. For each item in the slice, the function creates
+// a builder and applies setFunc on it.
+func (c *SkillClient) MapCreateBulk(slice any, setFunc func(*SkillCreate, int)) *SkillCreateBulk {
+	rv := reflect.ValueOf(slice)
+	if rv.Kind() != reflect.Slice {
+		return &SkillCreateBulk{err: fmt.Errorf("calling to SkillClient.MapCreateBulk with wrong type %T, need slice", slice)}
+	}
+	builders := make([]*SkillCreate, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		builders[i] = c.Create()
+		setFunc(builders[i], i)
+	}
+	return &SkillCreateBulk{config: c.config, builders: builders}
+}
+
+// Update returns an update builder for Skill.
+func (c *SkillClient) Update() *SkillUpdate {
+	mutation := newSkillMutation(c.config, OpUpdate)
+	return &SkillUpdate{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// UpdateOne returns an update builder for the given entity.
+func (c *SkillClient) UpdateOne(_m *Skill) *SkillUpdateOne {
+	mutation := newSkillMutation(c.config, OpUpdateOne, withSkill(_m))
+	return &SkillUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// UpdateOneID returns an update builder for the given id.
+func (c *SkillClient) UpdateOneID(id int) *SkillUpdateOne {
+	mutation := newSkillMutation(c.config, OpUpdateOne, withSkillID(id))
+	return &SkillUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// Delete returns a delete builder for Skill.
+func (c *SkillClient) Delete() *SkillDelete {
+	mutation := newSkillMutation(c.config, OpDelete)
+	return &SkillDelete{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// DeleteOne returns a builder for deleting the given entity.
+func (c *SkillClient) DeleteOne(_m *Skill) *SkillDeleteOne {
+	return c.DeleteOneID(_m.ID)
+}
+
+// DeleteOneID returns a builder for deleting the given entity by its id.
+func (c *SkillClient) DeleteOneID(id int) *SkillDeleteOne {
+	builder := c.Delete().Where(skill.ID(id))
+	builder.mutation.id = &id
+	builder.mutation.op = OpDeleteOne
+	return &SkillDeleteOne{builder}
+}
+
+// Query returns a query builder for Skill.
+func (c *SkillClient) Query() *SkillQuery {
+	return &SkillQuery{
+		config: c.config,
+		ctx:    &QueryContext{Type: TypeSkill},
+		inters: c.Interceptors(),
+	}
+}
+
+// Get returns a Skill entity by its id.
+func (c *SkillClient) Get(ctx context.Context, id int) (*Skill, error) {
+	return c.Query().Where(skill.ID(id)).Only(ctx)
+}
+
+// GetX is like Get, but panics if an error occurs.
+func (c *SkillClient) GetX(ctx context.Context, id int) *Skill {
+	obj, err := c.Get(ctx, id)
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+// QueryCharacters queries the characters edge of a Skill.
+func (c *SkillClient) QueryCharacters(_m *Skill) *CharacterSkillQuery {
+	query := (&CharacterSkillClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(skill.Table, skill.FieldID, id),
+			sqlgraph.To(characterskill.Table, characterskill.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, skill.CharactersTable, skill.CharactersColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// Hooks returns the client hooks.
+func (c *SkillClient) Hooks() []Hook {
+	return c.hooks.Skill
+}
+
+// Interceptors returns the client interceptors.
+func (c *SkillClient) Interceptors() []Interceptor {
+	return c.inters.Skill
+}
+
+func (c *SkillClient) mutate(ctx context.Context, m *SkillMutation) (Value, error) {
+	switch m.Op() {
+	case OpCreate:
+		return (&SkillCreate{config: c.config, hooks: c.Hooks(), mutation: m}).Save(ctx)
+	case OpUpdate:
+		return (&SkillUpdate{config: c.config, hooks: c.Hooks(), mutation: m}).Save(ctx)
+	case OpUpdateOne:
+		return (&SkillUpdateOne{config: c.config, hooks: c.Hooks(), mutation: m}).Save(ctx)
+	case OpDelete, OpDeleteOne:
+		return (&SkillDelete{config: c.config, hooks: c.Hooks(), mutation: m}).Exec(ctx)
+	default:
+		return nil, fmt.Errorf("db: unknown Skill mutation op: %q", m.Op())
+	}
+}
+
+// TalentClient is a client for the Talent schema.
+type TalentClient struct {
+	config
+}
+
+// NewTalentClient returns a client for the Talent from the given config.
+func NewTalentClient(c config) *TalentClient {
+	return &TalentClient{config: c}
+}
+
+// Use adds a list of mutation hooks to the hooks stack.
+// A call to `Use(f, g, h)` equals to `talent.Hooks(f(g(h())))`.
+func (c *TalentClient) Use(hooks ...Hook) {
+	c.hooks.Talent = append(c.hooks.Talent, hooks...)
+}
+
+// Intercept adds a list of query interceptors to the interceptors stack.
+// A call to `Intercept(f, g, h)` equals to `talent.Intercept(f(g(h())))`.
+func (c *TalentClient) Intercept(interceptors ...Interceptor) {
+	c.inters.Talent = append(c.inters.Talent, interceptors...)
+}
+
+// Create returns a builder for creating a Talent entity.
+func (c *TalentClient) Create() *TalentCreate {
+	mutation := newTalentMutation(c.config, OpCreate)
+	return &TalentCreate{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// CreateBulk returns a builder for creating a bulk of Talent entities.
+func (c *TalentClient) CreateBulk(builders ...*TalentCreate) *TalentCreateBulk {
+	return &TalentCreateBulk{config: c.config, builders: builders}
+}
+
+// MapCreateBulk creates a bulk creation builder from the given slice. For each item in the slice, the function creates
+// a builder and applies setFunc on it.
+func (c *TalentClient) MapCreateBulk(slice any, setFunc func(*TalentCreate, int)) *TalentCreateBulk {
+	rv := reflect.ValueOf(slice)
+	if rv.Kind() != reflect.Slice {
+		return &TalentCreateBulk{err: fmt.Errorf("calling to TalentClient.MapCreateBulk with wrong type %T, need slice", slice)}
+	}
+	builders := make([]*TalentCreate, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		builders[i] = c.Create()
+		setFunc(builders[i], i)
+	}
+	return &TalentCreateBulk{config: c.config, builders: builders}
+}
+
+// Update returns an update builder for Talent.
+func (c *TalentClient) Update() *TalentUpdate {
+	mutation := newTalentMutation(c.config, OpUpdate)
+	return &TalentUpdate{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// UpdateOne returns an update builder for the given entity.
+func (c *TalentClient) UpdateOne(_m *Talent) *TalentUpdateOne {
+	mutation := newTalentMutation(c.config, OpUpdateOne, withTalent(_m))
+	return &TalentUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// UpdateOneID returns an update builder for the given id.
+func (c *TalentClient) UpdateOneID(id int) *TalentUpdateOne {
+	mutation := newTalentMutation(c.config, OpUpdateOne, withTalentID(id))
+	return &TalentUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// Delete returns a delete builder for Talent.
+func (c *TalentClient) Delete() *TalentDelete {
+	mutation := newTalentMutation(c.config, OpDelete)
+	return &TalentDelete{config: c.config, hooks: c.Hooks(), mutation: mutation}
+}
+
+// DeleteOne returns a builder for deleting the given entity.
+func (c *TalentClient) DeleteOne(_m *Talent) *TalentDeleteOne {
+	return c.DeleteOneID(_m.ID)
+}
+
+// DeleteOneID returns a builder for deleting the given entity by its id.
+func (c *TalentClient) DeleteOneID(id int) *TalentDeleteOne {
+	builder := c.Delete().Where(talent.ID(id))
+	builder.mutation.id = &id
+	builder.mutation.op = OpDeleteOne
+	return &TalentDeleteOne{builder}
+}
+
+// Query returns a query builder for Talent.
+func (c *TalentClient) Query() *TalentQuery {
+	return &TalentQuery{
+		config: c.config,
+		ctx:    &QueryContext{Type: TypeTalent},
+		inters: c.Interceptors(),
+	}
+}
+
+// Get returns a Talent entity by its id.
+func (c *TalentClient) Get(ctx context.Context, id int) (*Talent, error) {
+	return c.Query().Where(talent.ID(id)).Only(ctx)
+}
+
+// GetX is like Get, but panics if an error occurs.
+func (c *TalentClient) GetX(ctx context.Context, id int) *Talent {
+	obj, err := c.Get(ctx, id)
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+// QueryCharacters queries the characters edge of a Talent.
+func (c *TalentClient) QueryCharacters(_m *Talent) *CharacterTalentQuery {
+	query := (&CharacterTalentClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(talent.Table, talent.FieldID, id),
+			sqlgraph.To(charactertalent.Table, charactertalent.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, talent.CharactersTable, talent.CharactersColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryAvailableToCharacters queries the available_to_characters edge of a Talent.
+func (c *TalentClient) QueryAvailableToCharacters(_m *Talent) *AvailableTalentQuery {
+	query := (&AvailableTalentClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(talent.Table, talent.FieldID, id),
+			sqlgraph.To(availabletalent.Table, availabletalent.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, talent.AvailableToCharactersTable, talent.AvailableToCharactersPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// Hooks returns the client hooks.
+func (c *TalentClient) Hooks() []Hook {
+	return c.hooks.Talent
+}
+
+// Interceptors returns the client interceptors.
+func (c *TalentClient) Interceptors() []Interceptor {
+	return c.inters.Talent
+}
+
+func (c *TalentClient) mutate(ctx context.Context, m *TalentMutation) (Value, error) {
+	switch m.Op() {
+	case OpCreate:
+		return (&TalentCreate{config: c.config, hooks: c.Hooks(), mutation: m}).Save(ctx)
+	case OpUpdate:
+		return (&TalentUpdate{config: c.config, hooks: c.Hooks(), mutation: m}).Save(ctx)
+	case OpUpdateOne:
+		return (&TalentUpdateOne{config: c.config, hooks: c.Hooks(), mutation: m}).Save(ctx)
+	case OpDelete, OpDeleteOne:
+		return (&TalentDelete{config: c.config, hooks: c.Hooks(), mutation: m}).Exec(ctx)
+	default:
+		return nil, fmt.Errorf("db: unknown Talent mutation op: %q", m.Op())
+	}
+}
+
 // UserClient is a client for the User schema.
 type UserClient struct {
 	config
@@ -1018,9 +1917,11 @@ func (c *UserClient) mutate(ctx context.Context, m *UserMutation) (Value, error)
 // hooks and interceptors per client, for fast access.
 type (
 	hooks struct {
-		Character, Equipment, NPCTemplate, Room, User []ent.Hook
+		AvailableTalent, Character, CharacterSkill, CharacterTalent, Equipment,
+		NPCTemplate, Room, Skill, Talent, User []ent.Hook
 	}
 	inters struct {
-		Character, Equipment, NPCTemplate, Room, User []ent.Interceptor
+		AvailableTalent, Character, CharacterSkill, CharacterTalent, Equipment,
+		NPCTemplate, Room, Skill, Talent, User []ent.Interceptor
 	}
 )

--- a/server/db/ent.go
+++ b/server/db/ent.go
@@ -6,10 +6,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"herbst-server/db/availabletalent"
 	"herbst-server/db/character"
+	"herbst-server/db/characterskill"
+	"herbst-server/db/charactertalent"
 	"herbst-server/db/equipment"
 	"herbst-server/db/npctemplate"
 	"herbst-server/db/room"
+	"herbst-server/db/skill"
+	"herbst-server/db/talent"
 	"herbst-server/db/user"
 	"reflect"
 	"sync"
@@ -77,11 +82,16 @@ var (
 func checkColumn(t, c string) error {
 	initCheck.Do(func() {
 		columnCheck = sql.NewColumnCheck(map[string]func(string) bool{
-			character.Table:   character.ValidColumn,
-			equipment.Table:   equipment.ValidColumn,
-			npctemplate.Table: npctemplate.ValidColumn,
-			room.Table:        room.ValidColumn,
-			user.Table:        user.ValidColumn,
+			availabletalent.Table: availabletalent.ValidColumn,
+			character.Table:       character.ValidColumn,
+			characterskill.Table:  characterskill.ValidColumn,
+			charactertalent.Table: charactertalent.ValidColumn,
+			equipment.Table:       equipment.ValidColumn,
+			npctemplate.Table:     npctemplate.ValidColumn,
+			room.Table:            room.ValidColumn,
+			skill.Table:           skill.ValidColumn,
+			talent.Table:          talent.ValidColumn,
+			user.Table:            user.ValidColumn,
 		})
 	})
 	return columnCheck(t, c)

--- a/server/db/migrate/schema.go
+++ b/server/db/migrate/schema.go
@@ -8,6 +8,18 @@ import (
 )
 
 var (
+	// AvailableTalentsColumns holds the columns for the "available_talents" table.
+	AvailableTalentsColumns = []*schema.Column{
+		{Name: "id", Type: field.TypeInt, Increment: true},
+		{Name: "unlock_reason", Type: field.TypeString, Nullable: true, Default: "level_up"},
+		{Name: "unlocked_at_level", Type: field.TypeInt, Default: 1},
+	}
+	// AvailableTalentsTable holds the schema information for the "available_talents" table.
+	AvailableTalentsTable = &schema.Table{
+		Name:       "available_talents",
+		Columns:    AvailableTalentsColumns,
+		PrimaryKey: []*schema.Column{AvailableTalentsColumns[0]},
+	}
 	// CharactersColumns holds the columns for the "characters" table.
 	CharactersColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
@@ -24,6 +36,7 @@ var (
 		{Name: "max_mana", Type: field.TypeInt, Default: 25},
 		{Name: "race", Type: field.TypeString, Default: "human"},
 		{Name: "class", Type: field.TypeString, Default: "adventurer"},
+		{Name: "specialty", Type: field.TypeString, Nullable: true},
 		{Name: "level", Type: field.TypeInt, Default: 1},
 		{Name: "constitution", Type: field.TypeInt, Default: 10},
 		{Name: "gender", Type: field.TypeString, Nullable: true},
@@ -54,26 +67,81 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "characters_rooms_room",
-				Columns:    []*schema.Column{CharactersColumns[31]},
+				Columns:    []*schema.Column{CharactersColumns[32]},
 				RefColumns: []*schema.Column{RoomsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "characters_npc_templates_npcTemplate",
-				Columns:    []*schema.Column{CharactersColumns[32]},
+				Columns:    []*schema.Column{CharactersColumns[33]},
 				RefColumns: []*schema.Column{NpcTemplatesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "characters_rooms_characters",
-				Columns:    []*schema.Column{CharactersColumns[33]},
+				Columns:    []*schema.Column{CharactersColumns[34]},
 				RefColumns: []*schema.Column{RoomsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "characters_users_characters",
-				Columns:    []*schema.Column{CharactersColumns[34]},
+				Columns:    []*schema.Column{CharactersColumns[35]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+		},
+	}
+	// CharacterSkillsColumns holds the columns for the "character_skills" table.
+	CharacterSkillsColumns = []*schema.Column{
+		{Name: "id", Type: field.TypeInt, Increment: true},
+		{Name: "level", Type: field.TypeInt, Default: 1},
+		{Name: "experience", Type: field.TypeInt, Default: 0},
+		{Name: "character_skills", Type: field.TypeInt, Nullable: true},
+		{Name: "skill_characters", Type: field.TypeInt, Nullable: true},
+	}
+	// CharacterSkillsTable holds the schema information for the "character_skills" table.
+	CharacterSkillsTable = &schema.Table{
+		Name:       "character_skills",
+		Columns:    CharacterSkillsColumns,
+		PrimaryKey: []*schema.Column{CharacterSkillsColumns[0]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "character_skills_characters_skills",
+				Columns:    []*schema.Column{CharacterSkillsColumns[3]},
+				RefColumns: []*schema.Column{CharactersColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+			{
+				Symbol:     "character_skills_skills_characters",
+				Columns:    []*schema.Column{CharacterSkillsColumns[4]},
+				RefColumns: []*schema.Column{SkillsColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+		},
+	}
+	// CharacterTalentsColumns holds the columns for the "character_talents" table.
+	CharacterTalentsColumns = []*schema.Column{
+		{Name: "id", Type: field.TypeInt, Increment: true},
+		{Name: "slot", Type: field.TypeInt, Default: 0},
+		{Name: "character_talents", Type: field.TypeInt, Nullable: true},
+		{Name: "talent_characters", Type: field.TypeInt, Nullable: true},
+	}
+	// CharacterTalentsTable holds the schema information for the "character_talents" table.
+	CharacterTalentsTable = &schema.Table{
+		Name:       "character_talents",
+		Columns:    CharacterTalentsColumns,
+		PrimaryKey: []*schema.Column{CharacterTalentsColumns[0]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "character_talents_characters_talents",
+				Columns:    []*schema.Column{CharacterTalentsColumns[2]},
+				RefColumns: []*schema.Column{CharactersColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+			{
+				Symbol:     "character_talents_talents_characters",
+				Columns:    []*schema.Column{CharacterTalentsColumns[3]},
+				RefColumns: []*schema.Column{TalentsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 		},
@@ -136,6 +204,35 @@ var (
 		Columns:    RoomsColumns,
 		PrimaryKey: []*schema.Column{RoomsColumns[0]},
 	}
+	// SkillsColumns holds the columns for the "skills" table.
+	SkillsColumns = []*schema.Column{
+		{Name: "id", Type: field.TypeInt, Increment: true},
+		{Name: "name", Type: field.TypeString, Unique: true},
+		{Name: "description", Type: field.TypeString},
+		{Name: "skill_type", Type: field.TypeString},
+		{Name: "cost", Type: field.TypeInt, Default: 0},
+		{Name: "cooldown", Type: field.TypeInt, Default: 0},
+		{Name: "requirements", Type: field.TypeString, Nullable: true},
+	}
+	// SkillsTable holds the schema information for the "skills" table.
+	SkillsTable = &schema.Table{
+		Name:       "skills",
+		Columns:    SkillsColumns,
+		PrimaryKey: []*schema.Column{SkillsColumns[0]},
+	}
+	// TalentsColumns holds the columns for the "talents" table.
+	TalentsColumns = []*schema.Column{
+		{Name: "id", Type: field.TypeInt, Increment: true},
+		{Name: "name", Type: field.TypeString, Unique: true},
+		{Name: "description", Type: field.TypeString},
+		{Name: "requirements", Type: field.TypeString, Nullable: true},
+	}
+	// TalentsTable holds the schema information for the "talents" table.
+	TalentsTable = &schema.Table{
+		Name:       "talents",
+		Columns:    TalentsColumns,
+		PrimaryKey: []*schema.Column{TalentsColumns[0]},
+	}
 	// UsersColumns holds the columns for the "users" table.
 	UsersColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
@@ -150,13 +247,70 @@ var (
 		Columns:    UsersColumns,
 		PrimaryKey: []*schema.Column{UsersColumns[0]},
 	}
+	// CharacterAvailableTalentsColumns holds the columns for the "character_available_talents" table.
+	CharacterAvailableTalentsColumns = []*schema.Column{
+		{Name: "character_id", Type: field.TypeInt},
+		{Name: "available_talent_id", Type: field.TypeInt},
+	}
+	// CharacterAvailableTalentsTable holds the schema information for the "character_available_talents" table.
+	CharacterAvailableTalentsTable = &schema.Table{
+		Name:       "character_available_talents",
+		Columns:    CharacterAvailableTalentsColumns,
+		PrimaryKey: []*schema.Column{CharacterAvailableTalentsColumns[0], CharacterAvailableTalentsColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "character_available_talents_character_id",
+				Columns:    []*schema.Column{CharacterAvailableTalentsColumns[0]},
+				RefColumns: []*schema.Column{CharactersColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "character_available_talents_available_talent_id",
+				Columns:    []*schema.Column{CharacterAvailableTalentsColumns[1]},
+				RefColumns: []*schema.Column{AvailableTalentsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
+	// TalentAvailableToCharactersColumns holds the columns for the "talent_available_to_characters" table.
+	TalentAvailableToCharactersColumns = []*schema.Column{
+		{Name: "talent_id", Type: field.TypeInt},
+		{Name: "available_talent_id", Type: field.TypeInt},
+	}
+	// TalentAvailableToCharactersTable holds the schema information for the "talent_available_to_characters" table.
+	TalentAvailableToCharactersTable = &schema.Table{
+		Name:       "talent_available_to_characters",
+		Columns:    TalentAvailableToCharactersColumns,
+		PrimaryKey: []*schema.Column{TalentAvailableToCharactersColumns[0], TalentAvailableToCharactersColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "talent_available_to_characters_talent_id",
+				Columns:    []*schema.Column{TalentAvailableToCharactersColumns[0]},
+				RefColumns: []*schema.Column{TalentsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "talent_available_to_characters_available_talent_id",
+				Columns:    []*schema.Column{TalentAvailableToCharactersColumns[1]},
+				RefColumns: []*schema.Column{AvailableTalentsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
 	// Tables holds all the tables in the schema.
 	Tables = []*schema.Table{
+		AvailableTalentsTable,
 		CharactersTable,
+		CharacterSkillsTable,
+		CharacterTalentsTable,
 		EquipmentTable,
 		NpcTemplatesTable,
 		RoomsTable,
+		SkillsTable,
+		TalentsTable,
 		UsersTable,
+		CharacterAvailableTalentsTable,
+		TalentAvailableToCharactersTable,
 	}
 )
 
@@ -165,5 +319,13 @@ func init() {
 	CharactersTable.ForeignKeys[1].RefTable = NpcTemplatesTable
 	CharactersTable.ForeignKeys[2].RefTable = RoomsTable
 	CharactersTable.ForeignKeys[3].RefTable = UsersTable
+	CharacterSkillsTable.ForeignKeys[0].RefTable = CharactersTable
+	CharacterSkillsTable.ForeignKeys[1].RefTable = SkillsTable
+	CharacterTalentsTable.ForeignKeys[0].RefTable = CharactersTable
+	CharacterTalentsTable.ForeignKeys[1].RefTable = TalentsTable
 	EquipmentTable.ForeignKeys[0].RefTable = RoomsTable
+	CharacterAvailableTalentsTable.ForeignKeys[0].RefTable = CharactersTable
+	CharacterAvailableTalentsTable.ForeignKeys[1].RefTable = AvailableTalentsTable
+	TalentAvailableToCharactersTable.ForeignKeys[0].RefTable = TalentsTable
+	TalentAvailableToCharactersTable.ForeignKeys[1].RefTable = AvailableTalentsTable
 }

--- a/server/db/mutation.go
+++ b/server/db/mutation.go
@@ -6,11 +6,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"herbst-server/db/availabletalent"
 	"herbst-server/db/character"
+	"herbst-server/db/characterskill"
+	"herbst-server/db/charactertalent"
 	"herbst-server/db/equipment"
 	"herbst-server/db/npctemplate"
 	"herbst-server/db/predicate"
 	"herbst-server/db/room"
+	"herbst-server/db/skill"
+	"herbst-server/db/talent"
 	"herbst-server/db/user"
 	"sync"
 
@@ -27,81 +32,710 @@ const (
 	OpUpdateOne = ent.OpUpdateOne
 
 	// Node types.
-	TypeCharacter   = "Character"
-	TypeEquipment   = "Equipment"
-	TypeNPCTemplate = "NPCTemplate"
-	TypeRoom        = "Room"
-	TypeUser        = "User"
+	TypeAvailableTalent = "AvailableTalent"
+	TypeCharacter       = "Character"
+	TypeCharacterSkill  = "CharacterSkill"
+	TypeCharacterTalent = "CharacterTalent"
+	TypeEquipment       = "Equipment"
+	TypeNPCTemplate     = "NPCTemplate"
+	TypeRoom            = "Room"
+	TypeSkill           = "Skill"
+	TypeTalent          = "Talent"
+	TypeUser            = "User"
 )
 
-// CharacterMutation represents an operation that mutates the Character nodes in the graph.
-type CharacterMutation struct {
+// AvailableTalentMutation represents an operation that mutates the AvailableTalent nodes in the graph.
+type AvailableTalentMutation struct {
 	config
 	op                   Op
 	typ                  string
 	id                   *int
-	name                 *string
-	password             *string
-	isNPC                *bool
-	startingRoomId       *int
-	addstartingRoomId    *int
-	is_admin             *bool
-	hitpoints            *int
-	addhitpoints         *int
-	max_hitpoints        *int
-	addmax_hitpoints     *int
-	stamina              *int
-	addstamina           *int
-	max_stamina          *int
-	addmax_stamina       *int
-	mana                 *int
-	addmana              *int
-	max_mana             *int
-	addmax_mana          *int
-	race                 *string
-	class                *string
-	level                *int
-	addlevel             *int
-	constitution         *int
-	addconstitution      *int
-	gender               *string
-	description          *string
-	strength             *int
-	addstrength          *int
-	dexterity            *int
-	adddexterity         *int
-	intelligence         *int
-	addintelligence      *int
-	wisdom               *int
-	addwisdom            *int
-	skill_blades         *int
-	addskill_blades      *int
-	skill_staves         *int
-	addskill_staves      *int
-	skill_knives         *int
-	addskill_knives      *int
-	skill_martial        *int
-	addskill_martial     *int
-	skill_brawling       *int
-	addskill_brawling    *int
-	skill_tech           *int
-	addskill_tech        *int
-	skill_light_armor    *int
-	addskill_light_armor *int
-	skill_cloth_armor    *int
-	addskill_cloth_armor *int
-	skill_heavy_armor    *int
-	addskill_heavy_armor *int
+	unlock_reason        *string
+	unlocked_at_level    *int
+	addunlocked_at_level *int
 	clearedFields        map[string]struct{}
-	user                 *int
-	cleareduser          bool
-	room                 *int
-	clearedroom          bool
-	npcTemplate          *string
-	clearednpcTemplate   bool
+	character            map[int]struct{}
+	removedcharacter     map[int]struct{}
+	clearedcharacter     bool
+	talent               map[int]struct{}
+	removedtalent        map[int]struct{}
+	clearedtalent        bool
 	done                 bool
-	oldValue             func(context.Context) (*Character, error)
-	predicates           []predicate.Character
+	oldValue             func(context.Context) (*AvailableTalent, error)
+	predicates           []predicate.AvailableTalent
+}
+
+var _ ent.Mutation = (*AvailableTalentMutation)(nil)
+
+// availabletalentOption allows management of the mutation configuration using functional options.
+type availabletalentOption func(*AvailableTalentMutation)
+
+// newAvailableTalentMutation creates new mutation for the AvailableTalent entity.
+func newAvailableTalentMutation(c config, op Op, opts ...availabletalentOption) *AvailableTalentMutation {
+	m := &AvailableTalentMutation{
+		config:        c,
+		op:            op,
+		typ:           TypeAvailableTalent,
+		clearedFields: make(map[string]struct{}),
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// withAvailableTalentID sets the ID field of the mutation.
+func withAvailableTalentID(id int) availabletalentOption {
+	return func(m *AvailableTalentMutation) {
+		var (
+			err   error
+			once  sync.Once
+			value *AvailableTalent
+		)
+		m.oldValue = func(ctx context.Context) (*AvailableTalent, error) {
+			once.Do(func() {
+				if m.done {
+					err = errors.New("querying old values post mutation is not allowed")
+				} else {
+					value, err = m.Client().AvailableTalent.Get(ctx, id)
+				}
+			})
+			return value, err
+		}
+		m.id = &id
+	}
+}
+
+// withAvailableTalent sets the old AvailableTalent of the mutation.
+func withAvailableTalent(node *AvailableTalent) availabletalentOption {
+	return func(m *AvailableTalentMutation) {
+		m.oldValue = func(context.Context) (*AvailableTalent, error) {
+			return node, nil
+		}
+		m.id = &node.ID
+	}
+}
+
+// Client returns a new `ent.Client` from the mutation. If the mutation was
+// executed in a transaction (ent.Tx), a transactional client is returned.
+func (m AvailableTalentMutation) Client() *Client {
+	client := &Client{config: m.config}
+	client.init()
+	return client
+}
+
+// Tx returns an `ent.Tx` for mutations that were executed in transactions;
+// it returns an error otherwise.
+func (m AvailableTalentMutation) Tx() (*Tx, error) {
+	if _, ok := m.driver.(*txDriver); !ok {
+		return nil, errors.New("db: mutation is not running in a transaction")
+	}
+	tx := &Tx{config: m.config}
+	tx.init()
+	return tx, nil
+}
+
+// ID returns the ID value in the mutation. Note that the ID is only available
+// if it was provided to the builder or after it was returned from the database.
+func (m *AvailableTalentMutation) ID() (id int, exists bool) {
+	if m.id == nil {
+		return
+	}
+	return *m.id, true
+}
+
+// IDs queries the database and returns the entity ids that match the mutation's predicate.
+// That means, if the mutation is applied within a transaction with an isolation level such
+// as sql.LevelSerializable, the returned ids match the ids of the rows that will be updated
+// or updated by the mutation.
+func (m *AvailableTalentMutation) IDs(ctx context.Context) ([]int, error) {
+	switch {
+	case m.op.Is(OpUpdateOne | OpDeleteOne):
+		id, exists := m.ID()
+		if exists {
+			return []int{id}, nil
+		}
+		fallthrough
+	case m.op.Is(OpUpdate | OpDelete):
+		return m.Client().AvailableTalent.Query().Where(m.predicates...).IDs(ctx)
+	default:
+		return nil, fmt.Errorf("IDs is not allowed on %s operations", m.op)
+	}
+}
+
+// SetUnlockReason sets the "unlock_reason" field.
+func (m *AvailableTalentMutation) SetUnlockReason(s string) {
+	m.unlock_reason = &s
+}
+
+// UnlockReason returns the value of the "unlock_reason" field in the mutation.
+func (m *AvailableTalentMutation) UnlockReason() (r string, exists bool) {
+	v := m.unlock_reason
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldUnlockReason returns the old "unlock_reason" field's value of the AvailableTalent entity.
+// If the AvailableTalent object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AvailableTalentMutation) OldUnlockReason(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldUnlockReason is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldUnlockReason requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldUnlockReason: %w", err)
+	}
+	return oldValue.UnlockReason, nil
+}
+
+// ClearUnlockReason clears the value of the "unlock_reason" field.
+func (m *AvailableTalentMutation) ClearUnlockReason() {
+	m.unlock_reason = nil
+	m.clearedFields[availabletalent.FieldUnlockReason] = struct{}{}
+}
+
+// UnlockReasonCleared returns if the "unlock_reason" field was cleared in this mutation.
+func (m *AvailableTalentMutation) UnlockReasonCleared() bool {
+	_, ok := m.clearedFields[availabletalent.FieldUnlockReason]
+	return ok
+}
+
+// ResetUnlockReason resets all changes to the "unlock_reason" field.
+func (m *AvailableTalentMutation) ResetUnlockReason() {
+	m.unlock_reason = nil
+	delete(m.clearedFields, availabletalent.FieldUnlockReason)
+}
+
+// SetUnlockedAtLevel sets the "unlocked_at_level" field.
+func (m *AvailableTalentMutation) SetUnlockedAtLevel(i int) {
+	m.unlocked_at_level = &i
+	m.addunlocked_at_level = nil
+}
+
+// UnlockedAtLevel returns the value of the "unlocked_at_level" field in the mutation.
+func (m *AvailableTalentMutation) UnlockedAtLevel() (r int, exists bool) {
+	v := m.unlocked_at_level
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldUnlockedAtLevel returns the old "unlocked_at_level" field's value of the AvailableTalent entity.
+// If the AvailableTalent object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AvailableTalentMutation) OldUnlockedAtLevel(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldUnlockedAtLevel is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldUnlockedAtLevel requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldUnlockedAtLevel: %w", err)
+	}
+	return oldValue.UnlockedAtLevel, nil
+}
+
+// AddUnlockedAtLevel adds i to the "unlocked_at_level" field.
+func (m *AvailableTalentMutation) AddUnlockedAtLevel(i int) {
+	if m.addunlocked_at_level != nil {
+		*m.addunlocked_at_level += i
+	} else {
+		m.addunlocked_at_level = &i
+	}
+}
+
+// AddedUnlockedAtLevel returns the value that was added to the "unlocked_at_level" field in this mutation.
+func (m *AvailableTalentMutation) AddedUnlockedAtLevel() (r int, exists bool) {
+	v := m.addunlocked_at_level
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetUnlockedAtLevel resets all changes to the "unlocked_at_level" field.
+func (m *AvailableTalentMutation) ResetUnlockedAtLevel() {
+	m.unlocked_at_level = nil
+	m.addunlocked_at_level = nil
+}
+
+// AddCharacterIDs adds the "character" edge to the Character entity by ids.
+func (m *AvailableTalentMutation) AddCharacterIDs(ids ...int) {
+	if m.character == nil {
+		m.character = make(map[int]struct{})
+	}
+	for i := range ids {
+		m.character[ids[i]] = struct{}{}
+	}
+}
+
+// ClearCharacter clears the "character" edge to the Character entity.
+func (m *AvailableTalentMutation) ClearCharacter() {
+	m.clearedcharacter = true
+}
+
+// CharacterCleared reports if the "character" edge to the Character entity was cleared.
+func (m *AvailableTalentMutation) CharacterCleared() bool {
+	return m.clearedcharacter
+}
+
+// RemoveCharacterIDs removes the "character" edge to the Character entity by IDs.
+func (m *AvailableTalentMutation) RemoveCharacterIDs(ids ...int) {
+	if m.removedcharacter == nil {
+		m.removedcharacter = make(map[int]struct{})
+	}
+	for i := range ids {
+		delete(m.character, ids[i])
+		m.removedcharacter[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedCharacter returns the removed IDs of the "character" edge to the Character entity.
+func (m *AvailableTalentMutation) RemovedCharacterIDs() (ids []int) {
+	for id := range m.removedcharacter {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// CharacterIDs returns the "character" edge IDs in the mutation.
+func (m *AvailableTalentMutation) CharacterIDs() (ids []int) {
+	for id := range m.character {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetCharacter resets all changes to the "character" edge.
+func (m *AvailableTalentMutation) ResetCharacter() {
+	m.character = nil
+	m.clearedcharacter = false
+	m.removedcharacter = nil
+}
+
+// AddTalentIDs adds the "talent" edge to the Talent entity by ids.
+func (m *AvailableTalentMutation) AddTalentIDs(ids ...int) {
+	if m.talent == nil {
+		m.talent = make(map[int]struct{})
+	}
+	for i := range ids {
+		m.talent[ids[i]] = struct{}{}
+	}
+}
+
+// ClearTalent clears the "talent" edge to the Talent entity.
+func (m *AvailableTalentMutation) ClearTalent() {
+	m.clearedtalent = true
+}
+
+// TalentCleared reports if the "talent" edge to the Talent entity was cleared.
+func (m *AvailableTalentMutation) TalentCleared() bool {
+	return m.clearedtalent
+}
+
+// RemoveTalentIDs removes the "talent" edge to the Talent entity by IDs.
+func (m *AvailableTalentMutation) RemoveTalentIDs(ids ...int) {
+	if m.removedtalent == nil {
+		m.removedtalent = make(map[int]struct{})
+	}
+	for i := range ids {
+		delete(m.talent, ids[i])
+		m.removedtalent[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedTalent returns the removed IDs of the "talent" edge to the Talent entity.
+func (m *AvailableTalentMutation) RemovedTalentIDs() (ids []int) {
+	for id := range m.removedtalent {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// TalentIDs returns the "talent" edge IDs in the mutation.
+func (m *AvailableTalentMutation) TalentIDs() (ids []int) {
+	for id := range m.talent {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetTalent resets all changes to the "talent" edge.
+func (m *AvailableTalentMutation) ResetTalent() {
+	m.talent = nil
+	m.clearedtalent = false
+	m.removedtalent = nil
+}
+
+// Where appends a list predicates to the AvailableTalentMutation builder.
+func (m *AvailableTalentMutation) Where(ps ...predicate.AvailableTalent) {
+	m.predicates = append(m.predicates, ps...)
+}
+
+// WhereP appends storage-level predicates to the AvailableTalentMutation builder. Using this method,
+// users can use type-assertion to append predicates that do not depend on any generated package.
+func (m *AvailableTalentMutation) WhereP(ps ...func(*sql.Selector)) {
+	p := make([]predicate.AvailableTalent, len(ps))
+	for i := range ps {
+		p[i] = ps[i]
+	}
+	m.Where(p...)
+}
+
+// Op returns the operation name.
+func (m *AvailableTalentMutation) Op() Op {
+	return m.op
+}
+
+// SetOp allows setting the mutation operation.
+func (m *AvailableTalentMutation) SetOp(op Op) {
+	m.op = op
+}
+
+// Type returns the node type of this mutation (AvailableTalent).
+func (m *AvailableTalentMutation) Type() string {
+	return m.typ
+}
+
+// Fields returns all fields that were changed during this mutation. Note that in
+// order to get all numeric fields that were incremented/decremented, call
+// AddedFields().
+func (m *AvailableTalentMutation) Fields() []string {
+	fields := make([]string, 0, 2)
+	if m.unlock_reason != nil {
+		fields = append(fields, availabletalent.FieldUnlockReason)
+	}
+	if m.unlocked_at_level != nil {
+		fields = append(fields, availabletalent.FieldUnlockedAtLevel)
+	}
+	return fields
+}
+
+// Field returns the value of a field with the given name. The second boolean
+// return value indicates that this field was not set, or was not defined in the
+// schema.
+func (m *AvailableTalentMutation) Field(name string) (ent.Value, bool) {
+	switch name {
+	case availabletalent.FieldUnlockReason:
+		return m.UnlockReason()
+	case availabletalent.FieldUnlockedAtLevel:
+		return m.UnlockedAtLevel()
+	}
+	return nil, false
+}
+
+// OldField returns the old value of the field from the database. An error is
+// returned if the mutation operation is not UpdateOne, or the query to the
+// database failed.
+func (m *AvailableTalentMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
+	switch name {
+	case availabletalent.FieldUnlockReason:
+		return m.OldUnlockReason(ctx)
+	case availabletalent.FieldUnlockedAtLevel:
+		return m.OldUnlockedAtLevel(ctx)
+	}
+	return nil, fmt.Errorf("unknown AvailableTalent field %s", name)
+}
+
+// SetField sets the value of a field with the given name. It returns an error if
+// the field is not defined in the schema, or if the type mismatched the field
+// type.
+func (m *AvailableTalentMutation) SetField(name string, value ent.Value) error {
+	switch name {
+	case availabletalent.FieldUnlockReason:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetUnlockReason(v)
+		return nil
+	case availabletalent.FieldUnlockedAtLevel:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetUnlockedAtLevel(v)
+		return nil
+	}
+	return fmt.Errorf("unknown AvailableTalent field %s", name)
+}
+
+// AddedFields returns all numeric fields that were incremented/decremented during
+// this mutation.
+func (m *AvailableTalentMutation) AddedFields() []string {
+	var fields []string
+	if m.addunlocked_at_level != nil {
+		fields = append(fields, availabletalent.FieldUnlockedAtLevel)
+	}
+	return fields
+}
+
+// AddedField returns the numeric value that was incremented/decremented on a field
+// with the given name. The second boolean return value indicates that this field
+// was not set, or was not defined in the schema.
+func (m *AvailableTalentMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	case availabletalent.FieldUnlockedAtLevel:
+		return m.AddedUnlockedAtLevel()
+	}
+	return nil, false
+}
+
+// AddField adds the value to the field with the given name. It returns an error if
+// the field is not defined in the schema, or if the type mismatched the field
+// type.
+func (m *AvailableTalentMutation) AddField(name string, value ent.Value) error {
+	switch name {
+	case availabletalent.FieldUnlockedAtLevel:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddUnlockedAtLevel(v)
+		return nil
+	}
+	return fmt.Errorf("unknown AvailableTalent numeric field %s", name)
+}
+
+// ClearedFields returns all nullable fields that were cleared during this
+// mutation.
+func (m *AvailableTalentMutation) ClearedFields() []string {
+	var fields []string
+	if m.FieldCleared(availabletalent.FieldUnlockReason) {
+		fields = append(fields, availabletalent.FieldUnlockReason)
+	}
+	return fields
+}
+
+// FieldCleared returns a boolean indicating if a field with the given name was
+// cleared in this mutation.
+func (m *AvailableTalentMutation) FieldCleared(name string) bool {
+	_, ok := m.clearedFields[name]
+	return ok
+}
+
+// ClearField clears the value of the field with the given name. It returns an
+// error if the field is not defined in the schema.
+func (m *AvailableTalentMutation) ClearField(name string) error {
+	switch name {
+	case availabletalent.FieldUnlockReason:
+		m.ClearUnlockReason()
+		return nil
+	}
+	return fmt.Errorf("unknown AvailableTalent nullable field %s", name)
+}
+
+// ResetField resets all changes in the mutation for the field with the given name.
+// It returns an error if the field is not defined in the schema.
+func (m *AvailableTalentMutation) ResetField(name string) error {
+	switch name {
+	case availabletalent.FieldUnlockReason:
+		m.ResetUnlockReason()
+		return nil
+	case availabletalent.FieldUnlockedAtLevel:
+		m.ResetUnlockedAtLevel()
+		return nil
+	}
+	return fmt.Errorf("unknown AvailableTalent field %s", name)
+}
+
+// AddedEdges returns all edge names that were set/added in this mutation.
+func (m *AvailableTalentMutation) AddedEdges() []string {
+	edges := make([]string, 0, 2)
+	if m.character != nil {
+		edges = append(edges, availabletalent.EdgeCharacter)
+	}
+	if m.talent != nil {
+		edges = append(edges, availabletalent.EdgeTalent)
+	}
+	return edges
+}
+
+// AddedIDs returns all IDs (to other nodes) that were added for the given edge
+// name in this mutation.
+func (m *AvailableTalentMutation) AddedIDs(name string) []ent.Value {
+	switch name {
+	case availabletalent.EdgeCharacter:
+		ids := make([]ent.Value, 0, len(m.character))
+		for id := range m.character {
+			ids = append(ids, id)
+		}
+		return ids
+	case availabletalent.EdgeTalent:
+		ids := make([]ent.Value, 0, len(m.talent))
+		for id := range m.talent {
+			ids = append(ids, id)
+		}
+		return ids
+	}
+	return nil
+}
+
+// RemovedEdges returns all edge names that were removed in this mutation.
+func (m *AvailableTalentMutation) RemovedEdges() []string {
+	edges := make([]string, 0, 2)
+	if m.removedcharacter != nil {
+		edges = append(edges, availabletalent.EdgeCharacter)
+	}
+	if m.removedtalent != nil {
+		edges = append(edges, availabletalent.EdgeTalent)
+	}
+	return edges
+}
+
+// RemovedIDs returns all IDs (to other nodes) that were removed for the edge with
+// the given name in this mutation.
+func (m *AvailableTalentMutation) RemovedIDs(name string) []ent.Value {
+	switch name {
+	case availabletalent.EdgeCharacter:
+		ids := make([]ent.Value, 0, len(m.removedcharacter))
+		for id := range m.removedcharacter {
+			ids = append(ids, id)
+		}
+		return ids
+	case availabletalent.EdgeTalent:
+		ids := make([]ent.Value, 0, len(m.removedtalent))
+		for id := range m.removedtalent {
+			ids = append(ids, id)
+		}
+		return ids
+	}
+	return nil
+}
+
+// ClearedEdges returns all edge names that were cleared in this mutation.
+func (m *AvailableTalentMutation) ClearedEdges() []string {
+	edges := make([]string, 0, 2)
+	if m.clearedcharacter {
+		edges = append(edges, availabletalent.EdgeCharacter)
+	}
+	if m.clearedtalent {
+		edges = append(edges, availabletalent.EdgeTalent)
+	}
+	return edges
+}
+
+// EdgeCleared returns a boolean which indicates if the edge with the given name
+// was cleared in this mutation.
+func (m *AvailableTalentMutation) EdgeCleared(name string) bool {
+	switch name {
+	case availabletalent.EdgeCharacter:
+		return m.clearedcharacter
+	case availabletalent.EdgeTalent:
+		return m.clearedtalent
+	}
+	return false
+}
+
+// ClearEdge clears the value of the edge with the given name. It returns an error
+// if that edge is not defined in the schema.
+func (m *AvailableTalentMutation) ClearEdge(name string) error {
+	switch name {
+	}
+	return fmt.Errorf("unknown AvailableTalent unique edge %s", name)
+}
+
+// ResetEdge resets all changes to the edge with the given name in this mutation.
+// It returns an error if the edge is not defined in the schema.
+func (m *AvailableTalentMutation) ResetEdge(name string) error {
+	switch name {
+	case availabletalent.EdgeCharacter:
+		m.ResetCharacter()
+		return nil
+	case availabletalent.EdgeTalent:
+		m.ResetTalent()
+		return nil
+	}
+	return fmt.Errorf("unknown AvailableTalent edge %s", name)
+}
+
+// CharacterMutation represents an operation that mutates the Character nodes in the graph.
+type CharacterMutation struct {
+	config
+	op                       Op
+	typ                      string
+	id                       *int
+	name                     *string
+	password                 *string
+	isNPC                    *bool
+	startingRoomId           *int
+	addstartingRoomId        *int
+	is_admin                 *bool
+	hitpoints                *int
+	addhitpoints             *int
+	max_hitpoints            *int
+	addmax_hitpoints         *int
+	stamina                  *int
+	addstamina               *int
+	max_stamina              *int
+	addmax_stamina           *int
+	mana                     *int
+	addmana                  *int
+	max_mana                 *int
+	addmax_mana              *int
+	race                     *string
+	class                    *string
+	specialty                *string
+	level                    *int
+	addlevel                 *int
+	constitution             *int
+	addconstitution          *int
+	gender                   *string
+	description              *string
+	strength                 *int
+	addstrength              *int
+	dexterity                *int
+	adddexterity             *int
+	intelligence             *int
+	addintelligence          *int
+	wisdom                   *int
+	addwisdom                *int
+	skill_blades             *int
+	addskill_blades          *int
+	skill_staves             *int
+	addskill_staves          *int
+	skill_knives             *int
+	addskill_knives          *int
+	skill_martial            *int
+	addskill_martial         *int
+	skill_brawling           *int
+	addskill_brawling        *int
+	skill_tech               *int
+	addskill_tech            *int
+	skill_light_armor        *int
+	addskill_light_armor     *int
+	skill_cloth_armor        *int
+	addskill_cloth_armor     *int
+	skill_heavy_armor        *int
+	addskill_heavy_armor     *int
+	clearedFields            map[string]struct{}
+	user                     *int
+	cleareduser              bool
+	room                     *int
+	clearedroom              bool
+	npcTemplate              *string
+	clearednpcTemplate       bool
+	available_talents        map[int]struct{}
+	removedavailable_talents map[int]struct{}
+	clearedavailable_talents bool
+	skills                   map[int]struct{}
+	removedskills            map[int]struct{}
+	clearedskills            bool
+	talents                  map[int]struct{}
+	removedtalents           map[int]struct{}
+	clearedtalents           bool
+	done                     bool
+	oldValue                 func(context.Context) (*Character, error)
+	predicates               []predicate.Character
 }
 
 var _ ent.Mutation = (*CharacterMutation)(nil)
@@ -857,6 +1491,55 @@ func (m *CharacterMutation) OldClass(ctx context.Context) (v string, err error) 
 // ResetClass resets all changes to the "class" field.
 func (m *CharacterMutation) ResetClass() {
 	m.class = nil
+}
+
+// SetSpecialty sets the "specialty" field.
+func (m *CharacterMutation) SetSpecialty(s string) {
+	m.specialty = &s
+}
+
+// Specialty returns the value of the "specialty" field in the mutation.
+func (m *CharacterMutation) Specialty() (r string, exists bool) {
+	v := m.specialty
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSpecialty returns the old "specialty" field's value of the Character entity.
+// If the Character object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CharacterMutation) OldSpecialty(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSpecialty is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSpecialty requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSpecialty: %w", err)
+	}
+	return oldValue.Specialty, nil
+}
+
+// ClearSpecialty clears the value of the "specialty" field.
+func (m *CharacterMutation) ClearSpecialty() {
+	m.specialty = nil
+	m.clearedFields[character.FieldSpecialty] = struct{}{}
+}
+
+// SpecialtyCleared returns if the "specialty" field was cleared in this mutation.
+func (m *CharacterMutation) SpecialtyCleared() bool {
+	_, ok := m.clearedFields[character.FieldSpecialty]
+	return ok
+}
+
+// ResetSpecialty resets all changes to the "specialty" field.
+func (m *CharacterMutation) ResetSpecialty() {
+	m.specialty = nil
+	delete(m.clearedFields, character.FieldSpecialty)
 }
 
 // SetLevel sets the "level" field.
@@ -1915,6 +2598,168 @@ func (m *CharacterMutation) ResetNpcTemplate() {
 	m.clearednpcTemplate = false
 }
 
+// AddAvailableTalentIDs adds the "available_talents" edge to the AvailableTalent entity by ids.
+func (m *CharacterMutation) AddAvailableTalentIDs(ids ...int) {
+	if m.available_talents == nil {
+		m.available_talents = make(map[int]struct{})
+	}
+	for i := range ids {
+		m.available_talents[ids[i]] = struct{}{}
+	}
+}
+
+// ClearAvailableTalents clears the "available_talents" edge to the AvailableTalent entity.
+func (m *CharacterMutation) ClearAvailableTalents() {
+	m.clearedavailable_talents = true
+}
+
+// AvailableTalentsCleared reports if the "available_talents" edge to the AvailableTalent entity was cleared.
+func (m *CharacterMutation) AvailableTalentsCleared() bool {
+	return m.clearedavailable_talents
+}
+
+// RemoveAvailableTalentIDs removes the "available_talents" edge to the AvailableTalent entity by IDs.
+func (m *CharacterMutation) RemoveAvailableTalentIDs(ids ...int) {
+	if m.removedavailable_talents == nil {
+		m.removedavailable_talents = make(map[int]struct{})
+	}
+	for i := range ids {
+		delete(m.available_talents, ids[i])
+		m.removedavailable_talents[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedAvailableTalents returns the removed IDs of the "available_talents" edge to the AvailableTalent entity.
+func (m *CharacterMutation) RemovedAvailableTalentsIDs() (ids []int) {
+	for id := range m.removedavailable_talents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// AvailableTalentsIDs returns the "available_talents" edge IDs in the mutation.
+func (m *CharacterMutation) AvailableTalentsIDs() (ids []int) {
+	for id := range m.available_talents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetAvailableTalents resets all changes to the "available_talents" edge.
+func (m *CharacterMutation) ResetAvailableTalents() {
+	m.available_talents = nil
+	m.clearedavailable_talents = false
+	m.removedavailable_talents = nil
+}
+
+// AddSkillIDs adds the "skills" edge to the CharacterSkill entity by ids.
+func (m *CharacterMutation) AddSkillIDs(ids ...int) {
+	if m.skills == nil {
+		m.skills = make(map[int]struct{})
+	}
+	for i := range ids {
+		m.skills[ids[i]] = struct{}{}
+	}
+}
+
+// ClearSkills clears the "skills" edge to the CharacterSkill entity.
+func (m *CharacterMutation) ClearSkills() {
+	m.clearedskills = true
+}
+
+// SkillsCleared reports if the "skills" edge to the CharacterSkill entity was cleared.
+func (m *CharacterMutation) SkillsCleared() bool {
+	return m.clearedskills
+}
+
+// RemoveSkillIDs removes the "skills" edge to the CharacterSkill entity by IDs.
+func (m *CharacterMutation) RemoveSkillIDs(ids ...int) {
+	if m.removedskills == nil {
+		m.removedskills = make(map[int]struct{})
+	}
+	for i := range ids {
+		delete(m.skills, ids[i])
+		m.removedskills[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedSkills returns the removed IDs of the "skills" edge to the CharacterSkill entity.
+func (m *CharacterMutation) RemovedSkillsIDs() (ids []int) {
+	for id := range m.removedskills {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// SkillsIDs returns the "skills" edge IDs in the mutation.
+func (m *CharacterMutation) SkillsIDs() (ids []int) {
+	for id := range m.skills {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetSkills resets all changes to the "skills" edge.
+func (m *CharacterMutation) ResetSkills() {
+	m.skills = nil
+	m.clearedskills = false
+	m.removedskills = nil
+}
+
+// AddTalentIDs adds the "talents" edge to the CharacterTalent entity by ids.
+func (m *CharacterMutation) AddTalentIDs(ids ...int) {
+	if m.talents == nil {
+		m.talents = make(map[int]struct{})
+	}
+	for i := range ids {
+		m.talents[ids[i]] = struct{}{}
+	}
+}
+
+// ClearTalents clears the "talents" edge to the CharacterTalent entity.
+func (m *CharacterMutation) ClearTalents() {
+	m.clearedtalents = true
+}
+
+// TalentsCleared reports if the "talents" edge to the CharacterTalent entity was cleared.
+func (m *CharacterMutation) TalentsCleared() bool {
+	return m.clearedtalents
+}
+
+// RemoveTalentIDs removes the "talents" edge to the CharacterTalent entity by IDs.
+func (m *CharacterMutation) RemoveTalentIDs(ids ...int) {
+	if m.removedtalents == nil {
+		m.removedtalents = make(map[int]struct{})
+	}
+	for i := range ids {
+		delete(m.talents, ids[i])
+		m.removedtalents[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedTalents returns the removed IDs of the "talents" edge to the CharacterTalent entity.
+func (m *CharacterMutation) RemovedTalentsIDs() (ids []int) {
+	for id := range m.removedtalents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// TalentsIDs returns the "talents" edge IDs in the mutation.
+func (m *CharacterMutation) TalentsIDs() (ids []int) {
+	for id := range m.talents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetTalents resets all changes to the "talents" edge.
+func (m *CharacterMutation) ResetTalents() {
+	m.talents = nil
+	m.clearedtalents = false
+	m.removedtalents = nil
+}
+
 // Where appends a list predicates to the CharacterMutation builder.
 func (m *CharacterMutation) Where(ps ...predicate.Character) {
 	m.predicates = append(m.predicates, ps...)
@@ -1949,7 +2794,7 @@ func (m *CharacterMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CharacterMutation) Fields() []string {
-	fields := make([]string, 0, 31)
+	fields := make([]string, 0, 32)
 	if m.name != nil {
 		fields = append(fields, character.FieldName)
 	}
@@ -1991,6 +2836,9 @@ func (m *CharacterMutation) Fields() []string {
 	}
 	if m.class != nil {
 		fields = append(fields, character.FieldClass)
+	}
+	if m.specialty != nil {
+		fields = append(fields, character.FieldSpecialty)
 	}
 	if m.level != nil {
 		fields = append(fields, character.FieldLevel)
@@ -2079,6 +2927,8 @@ func (m *CharacterMutation) Field(name string) (ent.Value, bool) {
 		return m.Race()
 	case character.FieldClass:
 		return m.Class()
+	case character.FieldSpecialty:
+		return m.Specialty()
 	case character.FieldLevel:
 		return m.Level()
 	case character.FieldConstitution:
@@ -2150,6 +3000,8 @@ func (m *CharacterMutation) OldField(ctx context.Context, name string) (ent.Valu
 		return m.OldRace(ctx)
 	case character.FieldClass:
 		return m.OldClass(ctx)
+	case character.FieldSpecialty:
+		return m.OldSpecialty(ctx)
 	case character.FieldLevel:
 		return m.OldLevel(ctx)
 	case character.FieldConstitution:
@@ -2290,6 +3142,13 @@ func (m *CharacterMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetClass(v)
+		return nil
+	case character.FieldSpecialty:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSpecialty(v)
 		return nil
 	case character.FieldLevel:
 		v, ok := value.(int)
@@ -2710,6 +3569,9 @@ func (m *CharacterMutation) ClearedFields() []string {
 	if m.FieldCleared(character.FieldPassword) {
 		fields = append(fields, character.FieldPassword)
 	}
+	if m.FieldCleared(character.FieldSpecialty) {
+		fields = append(fields, character.FieldSpecialty)
+	}
 	if m.FieldCleared(character.FieldGender) {
 		fields = append(fields, character.FieldGender)
 	}
@@ -2732,6 +3594,9 @@ func (m *CharacterMutation) ClearField(name string) error {
 	switch name {
 	case character.FieldPassword:
 		m.ClearPassword()
+		return nil
+	case character.FieldSpecialty:
+		m.ClearSpecialty()
 		return nil
 	case character.FieldGender:
 		m.ClearGender()
@@ -2788,6 +3653,9 @@ func (m *CharacterMutation) ResetField(name string) error {
 		return nil
 	case character.FieldClass:
 		m.ResetClass()
+		return nil
+	case character.FieldSpecialty:
+		m.ResetSpecialty()
 		return nil
 	case character.FieldLevel:
 		m.ResetLevel()
@@ -2846,7 +3714,7 @@ func (m *CharacterMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *CharacterMutation) AddedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 6)
 	if m.user != nil {
 		edges = append(edges, character.EdgeUser)
 	}
@@ -2855,6 +3723,15 @@ func (m *CharacterMutation) AddedEdges() []string {
 	}
 	if m.npcTemplate != nil {
 		edges = append(edges, character.EdgeNpcTemplate)
+	}
+	if m.available_talents != nil {
+		edges = append(edges, character.EdgeAvailableTalents)
+	}
+	if m.skills != nil {
+		edges = append(edges, character.EdgeSkills)
+	}
+	if m.talents != nil {
+		edges = append(edges, character.EdgeTalents)
 	}
 	return edges
 }
@@ -2875,25 +3752,72 @@ func (m *CharacterMutation) AddedIDs(name string) []ent.Value {
 		if id := m.npcTemplate; id != nil {
 			return []ent.Value{*id}
 		}
+	case character.EdgeAvailableTalents:
+		ids := make([]ent.Value, 0, len(m.available_talents))
+		for id := range m.available_talents {
+			ids = append(ids, id)
+		}
+		return ids
+	case character.EdgeSkills:
+		ids := make([]ent.Value, 0, len(m.skills))
+		for id := range m.skills {
+			ids = append(ids, id)
+		}
+		return ids
+	case character.EdgeTalents:
+		ids := make([]ent.Value, 0, len(m.talents))
+		for id := range m.talents {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *CharacterMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 6)
+	if m.removedavailable_talents != nil {
+		edges = append(edges, character.EdgeAvailableTalents)
+	}
+	if m.removedskills != nil {
+		edges = append(edges, character.EdgeSkills)
+	}
+	if m.removedtalents != nil {
+		edges = append(edges, character.EdgeTalents)
+	}
 	return edges
 }
 
 // RemovedIDs returns all IDs (to other nodes) that were removed for the edge with
 // the given name in this mutation.
 func (m *CharacterMutation) RemovedIDs(name string) []ent.Value {
+	switch name {
+	case character.EdgeAvailableTalents:
+		ids := make([]ent.Value, 0, len(m.removedavailable_talents))
+		for id := range m.removedavailable_talents {
+			ids = append(ids, id)
+		}
+		return ids
+	case character.EdgeSkills:
+		ids := make([]ent.Value, 0, len(m.removedskills))
+		for id := range m.removedskills {
+			ids = append(ids, id)
+		}
+		return ids
+	case character.EdgeTalents:
+		ids := make([]ent.Value, 0, len(m.removedtalents))
+		for id := range m.removedtalents {
+			ids = append(ids, id)
+		}
+		return ids
+	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *CharacterMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 6)
 	if m.cleareduser {
 		edges = append(edges, character.EdgeUser)
 	}
@@ -2902,6 +3826,15 @@ func (m *CharacterMutation) ClearedEdges() []string {
 	}
 	if m.clearednpcTemplate {
 		edges = append(edges, character.EdgeNpcTemplate)
+	}
+	if m.clearedavailable_talents {
+		edges = append(edges, character.EdgeAvailableTalents)
+	}
+	if m.clearedskills {
+		edges = append(edges, character.EdgeSkills)
+	}
+	if m.clearedtalents {
+		edges = append(edges, character.EdgeTalents)
 	}
 	return edges
 }
@@ -2916,6 +3849,12 @@ func (m *CharacterMutation) EdgeCleared(name string) bool {
 		return m.clearedroom
 	case character.EdgeNpcTemplate:
 		return m.clearednpcTemplate
+	case character.EdgeAvailableTalents:
+		return m.clearedavailable_talents
+	case character.EdgeSkills:
+		return m.clearedskills
+	case character.EdgeTalents:
+		return m.clearedtalents
 	}
 	return false
 }
@@ -2950,8 +3889,1080 @@ func (m *CharacterMutation) ResetEdge(name string) error {
 	case character.EdgeNpcTemplate:
 		m.ResetNpcTemplate()
 		return nil
+	case character.EdgeAvailableTalents:
+		m.ResetAvailableTalents()
+		return nil
+	case character.EdgeSkills:
+		m.ResetSkills()
+		return nil
+	case character.EdgeTalents:
+		m.ResetTalents()
+		return nil
 	}
 	return fmt.Errorf("unknown Character edge %s", name)
+}
+
+// CharacterSkillMutation represents an operation that mutates the CharacterSkill nodes in the graph.
+type CharacterSkillMutation struct {
+	config
+	op               Op
+	typ              string
+	id               *int
+	level            *int
+	addlevel         *int
+	experience       *int
+	addexperience    *int
+	clearedFields    map[string]struct{}
+	character        *int
+	clearedcharacter bool
+	skill            *int
+	clearedskill     bool
+	done             bool
+	oldValue         func(context.Context) (*CharacterSkill, error)
+	predicates       []predicate.CharacterSkill
+}
+
+var _ ent.Mutation = (*CharacterSkillMutation)(nil)
+
+// characterskillOption allows management of the mutation configuration using functional options.
+type characterskillOption func(*CharacterSkillMutation)
+
+// newCharacterSkillMutation creates new mutation for the CharacterSkill entity.
+func newCharacterSkillMutation(c config, op Op, opts ...characterskillOption) *CharacterSkillMutation {
+	m := &CharacterSkillMutation{
+		config:        c,
+		op:            op,
+		typ:           TypeCharacterSkill,
+		clearedFields: make(map[string]struct{}),
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// withCharacterSkillID sets the ID field of the mutation.
+func withCharacterSkillID(id int) characterskillOption {
+	return func(m *CharacterSkillMutation) {
+		var (
+			err   error
+			once  sync.Once
+			value *CharacterSkill
+		)
+		m.oldValue = func(ctx context.Context) (*CharacterSkill, error) {
+			once.Do(func() {
+				if m.done {
+					err = errors.New("querying old values post mutation is not allowed")
+				} else {
+					value, err = m.Client().CharacterSkill.Get(ctx, id)
+				}
+			})
+			return value, err
+		}
+		m.id = &id
+	}
+}
+
+// withCharacterSkill sets the old CharacterSkill of the mutation.
+func withCharacterSkill(node *CharacterSkill) characterskillOption {
+	return func(m *CharacterSkillMutation) {
+		m.oldValue = func(context.Context) (*CharacterSkill, error) {
+			return node, nil
+		}
+		m.id = &node.ID
+	}
+}
+
+// Client returns a new `ent.Client` from the mutation. If the mutation was
+// executed in a transaction (ent.Tx), a transactional client is returned.
+func (m CharacterSkillMutation) Client() *Client {
+	client := &Client{config: m.config}
+	client.init()
+	return client
+}
+
+// Tx returns an `ent.Tx` for mutations that were executed in transactions;
+// it returns an error otherwise.
+func (m CharacterSkillMutation) Tx() (*Tx, error) {
+	if _, ok := m.driver.(*txDriver); !ok {
+		return nil, errors.New("db: mutation is not running in a transaction")
+	}
+	tx := &Tx{config: m.config}
+	tx.init()
+	return tx, nil
+}
+
+// ID returns the ID value in the mutation. Note that the ID is only available
+// if it was provided to the builder or after it was returned from the database.
+func (m *CharacterSkillMutation) ID() (id int, exists bool) {
+	if m.id == nil {
+		return
+	}
+	return *m.id, true
+}
+
+// IDs queries the database and returns the entity ids that match the mutation's predicate.
+// That means, if the mutation is applied within a transaction with an isolation level such
+// as sql.LevelSerializable, the returned ids match the ids of the rows that will be updated
+// or updated by the mutation.
+func (m *CharacterSkillMutation) IDs(ctx context.Context) ([]int, error) {
+	switch {
+	case m.op.Is(OpUpdateOne | OpDeleteOne):
+		id, exists := m.ID()
+		if exists {
+			return []int{id}, nil
+		}
+		fallthrough
+	case m.op.Is(OpUpdate | OpDelete):
+		return m.Client().CharacterSkill.Query().Where(m.predicates...).IDs(ctx)
+	default:
+		return nil, fmt.Errorf("IDs is not allowed on %s operations", m.op)
+	}
+}
+
+// SetLevel sets the "level" field.
+func (m *CharacterSkillMutation) SetLevel(i int) {
+	m.level = &i
+	m.addlevel = nil
+}
+
+// Level returns the value of the "level" field in the mutation.
+func (m *CharacterSkillMutation) Level() (r int, exists bool) {
+	v := m.level
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldLevel returns the old "level" field's value of the CharacterSkill entity.
+// If the CharacterSkill object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CharacterSkillMutation) OldLevel(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldLevel is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldLevel requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldLevel: %w", err)
+	}
+	return oldValue.Level, nil
+}
+
+// AddLevel adds i to the "level" field.
+func (m *CharacterSkillMutation) AddLevel(i int) {
+	if m.addlevel != nil {
+		*m.addlevel += i
+	} else {
+		m.addlevel = &i
+	}
+}
+
+// AddedLevel returns the value that was added to the "level" field in this mutation.
+func (m *CharacterSkillMutation) AddedLevel() (r int, exists bool) {
+	v := m.addlevel
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetLevel resets all changes to the "level" field.
+func (m *CharacterSkillMutation) ResetLevel() {
+	m.level = nil
+	m.addlevel = nil
+}
+
+// SetExperience sets the "experience" field.
+func (m *CharacterSkillMutation) SetExperience(i int) {
+	m.experience = &i
+	m.addexperience = nil
+}
+
+// Experience returns the value of the "experience" field in the mutation.
+func (m *CharacterSkillMutation) Experience() (r int, exists bool) {
+	v := m.experience
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldExperience returns the old "experience" field's value of the CharacterSkill entity.
+// If the CharacterSkill object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CharacterSkillMutation) OldExperience(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldExperience is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldExperience requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldExperience: %w", err)
+	}
+	return oldValue.Experience, nil
+}
+
+// AddExperience adds i to the "experience" field.
+func (m *CharacterSkillMutation) AddExperience(i int) {
+	if m.addexperience != nil {
+		*m.addexperience += i
+	} else {
+		m.addexperience = &i
+	}
+}
+
+// AddedExperience returns the value that was added to the "experience" field in this mutation.
+func (m *CharacterSkillMutation) AddedExperience() (r int, exists bool) {
+	v := m.addexperience
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetExperience resets all changes to the "experience" field.
+func (m *CharacterSkillMutation) ResetExperience() {
+	m.experience = nil
+	m.addexperience = nil
+}
+
+// SetCharacterID sets the "character" edge to the Character entity by id.
+func (m *CharacterSkillMutation) SetCharacterID(id int) {
+	m.character = &id
+}
+
+// ClearCharacter clears the "character" edge to the Character entity.
+func (m *CharacterSkillMutation) ClearCharacter() {
+	m.clearedcharacter = true
+}
+
+// CharacterCleared reports if the "character" edge to the Character entity was cleared.
+func (m *CharacterSkillMutation) CharacterCleared() bool {
+	return m.clearedcharacter
+}
+
+// CharacterID returns the "character" edge ID in the mutation.
+func (m *CharacterSkillMutation) CharacterID() (id int, exists bool) {
+	if m.character != nil {
+		return *m.character, true
+	}
+	return
+}
+
+// CharacterIDs returns the "character" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// CharacterID instead. It exists only for internal usage by the builders.
+func (m *CharacterSkillMutation) CharacterIDs() (ids []int) {
+	if id := m.character; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetCharacter resets all changes to the "character" edge.
+func (m *CharacterSkillMutation) ResetCharacter() {
+	m.character = nil
+	m.clearedcharacter = false
+}
+
+// SetSkillID sets the "skill" edge to the Skill entity by id.
+func (m *CharacterSkillMutation) SetSkillID(id int) {
+	m.skill = &id
+}
+
+// ClearSkill clears the "skill" edge to the Skill entity.
+func (m *CharacterSkillMutation) ClearSkill() {
+	m.clearedskill = true
+}
+
+// SkillCleared reports if the "skill" edge to the Skill entity was cleared.
+func (m *CharacterSkillMutation) SkillCleared() bool {
+	return m.clearedskill
+}
+
+// SkillID returns the "skill" edge ID in the mutation.
+func (m *CharacterSkillMutation) SkillID() (id int, exists bool) {
+	if m.skill != nil {
+		return *m.skill, true
+	}
+	return
+}
+
+// SkillIDs returns the "skill" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// SkillID instead. It exists only for internal usage by the builders.
+func (m *CharacterSkillMutation) SkillIDs() (ids []int) {
+	if id := m.skill; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetSkill resets all changes to the "skill" edge.
+func (m *CharacterSkillMutation) ResetSkill() {
+	m.skill = nil
+	m.clearedskill = false
+}
+
+// Where appends a list predicates to the CharacterSkillMutation builder.
+func (m *CharacterSkillMutation) Where(ps ...predicate.CharacterSkill) {
+	m.predicates = append(m.predicates, ps...)
+}
+
+// WhereP appends storage-level predicates to the CharacterSkillMutation builder. Using this method,
+// users can use type-assertion to append predicates that do not depend on any generated package.
+func (m *CharacterSkillMutation) WhereP(ps ...func(*sql.Selector)) {
+	p := make([]predicate.CharacterSkill, len(ps))
+	for i := range ps {
+		p[i] = ps[i]
+	}
+	m.Where(p...)
+}
+
+// Op returns the operation name.
+func (m *CharacterSkillMutation) Op() Op {
+	return m.op
+}
+
+// SetOp allows setting the mutation operation.
+func (m *CharacterSkillMutation) SetOp(op Op) {
+	m.op = op
+}
+
+// Type returns the node type of this mutation (CharacterSkill).
+func (m *CharacterSkillMutation) Type() string {
+	return m.typ
+}
+
+// Fields returns all fields that were changed during this mutation. Note that in
+// order to get all numeric fields that were incremented/decremented, call
+// AddedFields().
+func (m *CharacterSkillMutation) Fields() []string {
+	fields := make([]string, 0, 2)
+	if m.level != nil {
+		fields = append(fields, characterskill.FieldLevel)
+	}
+	if m.experience != nil {
+		fields = append(fields, characterskill.FieldExperience)
+	}
+	return fields
+}
+
+// Field returns the value of a field with the given name. The second boolean
+// return value indicates that this field was not set, or was not defined in the
+// schema.
+func (m *CharacterSkillMutation) Field(name string) (ent.Value, bool) {
+	switch name {
+	case characterskill.FieldLevel:
+		return m.Level()
+	case characterskill.FieldExperience:
+		return m.Experience()
+	}
+	return nil, false
+}
+
+// OldField returns the old value of the field from the database. An error is
+// returned if the mutation operation is not UpdateOne, or the query to the
+// database failed.
+func (m *CharacterSkillMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
+	switch name {
+	case characterskill.FieldLevel:
+		return m.OldLevel(ctx)
+	case characterskill.FieldExperience:
+		return m.OldExperience(ctx)
+	}
+	return nil, fmt.Errorf("unknown CharacterSkill field %s", name)
+}
+
+// SetField sets the value of a field with the given name. It returns an error if
+// the field is not defined in the schema, or if the type mismatched the field
+// type.
+func (m *CharacterSkillMutation) SetField(name string, value ent.Value) error {
+	switch name {
+	case characterskill.FieldLevel:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetLevel(v)
+		return nil
+	case characterskill.FieldExperience:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetExperience(v)
+		return nil
+	}
+	return fmt.Errorf("unknown CharacterSkill field %s", name)
+}
+
+// AddedFields returns all numeric fields that were incremented/decremented during
+// this mutation.
+func (m *CharacterSkillMutation) AddedFields() []string {
+	var fields []string
+	if m.addlevel != nil {
+		fields = append(fields, characterskill.FieldLevel)
+	}
+	if m.addexperience != nil {
+		fields = append(fields, characterskill.FieldExperience)
+	}
+	return fields
+}
+
+// AddedField returns the numeric value that was incremented/decremented on a field
+// with the given name. The second boolean return value indicates that this field
+// was not set, or was not defined in the schema.
+func (m *CharacterSkillMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	case characterskill.FieldLevel:
+		return m.AddedLevel()
+	case characterskill.FieldExperience:
+		return m.AddedExperience()
+	}
+	return nil, false
+}
+
+// AddField adds the value to the field with the given name. It returns an error if
+// the field is not defined in the schema, or if the type mismatched the field
+// type.
+func (m *CharacterSkillMutation) AddField(name string, value ent.Value) error {
+	switch name {
+	case characterskill.FieldLevel:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddLevel(v)
+		return nil
+	case characterskill.FieldExperience:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddExperience(v)
+		return nil
+	}
+	return fmt.Errorf("unknown CharacterSkill numeric field %s", name)
+}
+
+// ClearedFields returns all nullable fields that were cleared during this
+// mutation.
+func (m *CharacterSkillMutation) ClearedFields() []string {
+	return nil
+}
+
+// FieldCleared returns a boolean indicating if a field with the given name was
+// cleared in this mutation.
+func (m *CharacterSkillMutation) FieldCleared(name string) bool {
+	_, ok := m.clearedFields[name]
+	return ok
+}
+
+// ClearField clears the value of the field with the given name. It returns an
+// error if the field is not defined in the schema.
+func (m *CharacterSkillMutation) ClearField(name string) error {
+	return fmt.Errorf("unknown CharacterSkill nullable field %s", name)
+}
+
+// ResetField resets all changes in the mutation for the field with the given name.
+// It returns an error if the field is not defined in the schema.
+func (m *CharacterSkillMutation) ResetField(name string) error {
+	switch name {
+	case characterskill.FieldLevel:
+		m.ResetLevel()
+		return nil
+	case characterskill.FieldExperience:
+		m.ResetExperience()
+		return nil
+	}
+	return fmt.Errorf("unknown CharacterSkill field %s", name)
+}
+
+// AddedEdges returns all edge names that were set/added in this mutation.
+func (m *CharacterSkillMutation) AddedEdges() []string {
+	edges := make([]string, 0, 2)
+	if m.character != nil {
+		edges = append(edges, characterskill.EdgeCharacter)
+	}
+	if m.skill != nil {
+		edges = append(edges, characterskill.EdgeSkill)
+	}
+	return edges
+}
+
+// AddedIDs returns all IDs (to other nodes) that were added for the given edge
+// name in this mutation.
+func (m *CharacterSkillMutation) AddedIDs(name string) []ent.Value {
+	switch name {
+	case characterskill.EdgeCharacter:
+		if id := m.character; id != nil {
+			return []ent.Value{*id}
+		}
+	case characterskill.EdgeSkill:
+		if id := m.skill; id != nil {
+			return []ent.Value{*id}
+		}
+	}
+	return nil
+}
+
+// RemovedEdges returns all edge names that were removed in this mutation.
+func (m *CharacterSkillMutation) RemovedEdges() []string {
+	edges := make([]string, 0, 2)
+	return edges
+}
+
+// RemovedIDs returns all IDs (to other nodes) that were removed for the edge with
+// the given name in this mutation.
+func (m *CharacterSkillMutation) RemovedIDs(name string) []ent.Value {
+	return nil
+}
+
+// ClearedEdges returns all edge names that were cleared in this mutation.
+func (m *CharacterSkillMutation) ClearedEdges() []string {
+	edges := make([]string, 0, 2)
+	if m.clearedcharacter {
+		edges = append(edges, characterskill.EdgeCharacter)
+	}
+	if m.clearedskill {
+		edges = append(edges, characterskill.EdgeSkill)
+	}
+	return edges
+}
+
+// EdgeCleared returns a boolean which indicates if the edge with the given name
+// was cleared in this mutation.
+func (m *CharacterSkillMutation) EdgeCleared(name string) bool {
+	switch name {
+	case characterskill.EdgeCharacter:
+		return m.clearedcharacter
+	case characterskill.EdgeSkill:
+		return m.clearedskill
+	}
+	return false
+}
+
+// ClearEdge clears the value of the edge with the given name. It returns an error
+// if that edge is not defined in the schema.
+func (m *CharacterSkillMutation) ClearEdge(name string) error {
+	switch name {
+	case characterskill.EdgeCharacter:
+		m.ClearCharacter()
+		return nil
+	case characterskill.EdgeSkill:
+		m.ClearSkill()
+		return nil
+	}
+	return fmt.Errorf("unknown CharacterSkill unique edge %s", name)
+}
+
+// ResetEdge resets all changes to the edge with the given name in this mutation.
+// It returns an error if the edge is not defined in the schema.
+func (m *CharacterSkillMutation) ResetEdge(name string) error {
+	switch name {
+	case characterskill.EdgeCharacter:
+		m.ResetCharacter()
+		return nil
+	case characterskill.EdgeSkill:
+		m.ResetSkill()
+		return nil
+	}
+	return fmt.Errorf("unknown CharacterSkill edge %s", name)
+}
+
+// CharacterTalentMutation represents an operation that mutates the CharacterTalent nodes in the graph.
+type CharacterTalentMutation struct {
+	config
+	op               Op
+	typ              string
+	id               *int
+	slot             *int
+	addslot          *int
+	clearedFields    map[string]struct{}
+	character        *int
+	clearedcharacter bool
+	talent           *int
+	clearedtalent    bool
+	done             bool
+	oldValue         func(context.Context) (*CharacterTalent, error)
+	predicates       []predicate.CharacterTalent
+}
+
+var _ ent.Mutation = (*CharacterTalentMutation)(nil)
+
+// charactertalentOption allows management of the mutation configuration using functional options.
+type charactertalentOption func(*CharacterTalentMutation)
+
+// newCharacterTalentMutation creates new mutation for the CharacterTalent entity.
+func newCharacterTalentMutation(c config, op Op, opts ...charactertalentOption) *CharacterTalentMutation {
+	m := &CharacterTalentMutation{
+		config:        c,
+		op:            op,
+		typ:           TypeCharacterTalent,
+		clearedFields: make(map[string]struct{}),
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// withCharacterTalentID sets the ID field of the mutation.
+func withCharacterTalentID(id int) charactertalentOption {
+	return func(m *CharacterTalentMutation) {
+		var (
+			err   error
+			once  sync.Once
+			value *CharacterTalent
+		)
+		m.oldValue = func(ctx context.Context) (*CharacterTalent, error) {
+			once.Do(func() {
+				if m.done {
+					err = errors.New("querying old values post mutation is not allowed")
+				} else {
+					value, err = m.Client().CharacterTalent.Get(ctx, id)
+				}
+			})
+			return value, err
+		}
+		m.id = &id
+	}
+}
+
+// withCharacterTalent sets the old CharacterTalent of the mutation.
+func withCharacterTalent(node *CharacterTalent) charactertalentOption {
+	return func(m *CharacterTalentMutation) {
+		m.oldValue = func(context.Context) (*CharacterTalent, error) {
+			return node, nil
+		}
+		m.id = &node.ID
+	}
+}
+
+// Client returns a new `ent.Client` from the mutation. If the mutation was
+// executed in a transaction (ent.Tx), a transactional client is returned.
+func (m CharacterTalentMutation) Client() *Client {
+	client := &Client{config: m.config}
+	client.init()
+	return client
+}
+
+// Tx returns an `ent.Tx` for mutations that were executed in transactions;
+// it returns an error otherwise.
+func (m CharacterTalentMutation) Tx() (*Tx, error) {
+	if _, ok := m.driver.(*txDriver); !ok {
+		return nil, errors.New("db: mutation is not running in a transaction")
+	}
+	tx := &Tx{config: m.config}
+	tx.init()
+	return tx, nil
+}
+
+// ID returns the ID value in the mutation. Note that the ID is only available
+// if it was provided to the builder or after it was returned from the database.
+func (m *CharacterTalentMutation) ID() (id int, exists bool) {
+	if m.id == nil {
+		return
+	}
+	return *m.id, true
+}
+
+// IDs queries the database and returns the entity ids that match the mutation's predicate.
+// That means, if the mutation is applied within a transaction with an isolation level such
+// as sql.LevelSerializable, the returned ids match the ids of the rows that will be updated
+// or updated by the mutation.
+func (m *CharacterTalentMutation) IDs(ctx context.Context) ([]int, error) {
+	switch {
+	case m.op.Is(OpUpdateOne | OpDeleteOne):
+		id, exists := m.ID()
+		if exists {
+			return []int{id}, nil
+		}
+		fallthrough
+	case m.op.Is(OpUpdate | OpDelete):
+		return m.Client().CharacterTalent.Query().Where(m.predicates...).IDs(ctx)
+	default:
+		return nil, fmt.Errorf("IDs is not allowed on %s operations", m.op)
+	}
+}
+
+// SetSlot sets the "slot" field.
+func (m *CharacterTalentMutation) SetSlot(i int) {
+	m.slot = &i
+	m.addslot = nil
+}
+
+// Slot returns the value of the "slot" field in the mutation.
+func (m *CharacterTalentMutation) Slot() (r int, exists bool) {
+	v := m.slot
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSlot returns the old "slot" field's value of the CharacterTalent entity.
+// If the CharacterTalent object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CharacterTalentMutation) OldSlot(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSlot is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSlot requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSlot: %w", err)
+	}
+	return oldValue.Slot, nil
+}
+
+// AddSlot adds i to the "slot" field.
+func (m *CharacterTalentMutation) AddSlot(i int) {
+	if m.addslot != nil {
+		*m.addslot += i
+	} else {
+		m.addslot = &i
+	}
+}
+
+// AddedSlot returns the value that was added to the "slot" field in this mutation.
+func (m *CharacterTalentMutation) AddedSlot() (r int, exists bool) {
+	v := m.addslot
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetSlot resets all changes to the "slot" field.
+func (m *CharacterTalentMutation) ResetSlot() {
+	m.slot = nil
+	m.addslot = nil
+}
+
+// SetCharacterID sets the "character" edge to the Character entity by id.
+func (m *CharacterTalentMutation) SetCharacterID(id int) {
+	m.character = &id
+}
+
+// ClearCharacter clears the "character" edge to the Character entity.
+func (m *CharacterTalentMutation) ClearCharacter() {
+	m.clearedcharacter = true
+}
+
+// CharacterCleared reports if the "character" edge to the Character entity was cleared.
+func (m *CharacterTalentMutation) CharacterCleared() bool {
+	return m.clearedcharacter
+}
+
+// CharacterID returns the "character" edge ID in the mutation.
+func (m *CharacterTalentMutation) CharacterID() (id int, exists bool) {
+	if m.character != nil {
+		return *m.character, true
+	}
+	return
+}
+
+// CharacterIDs returns the "character" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// CharacterID instead. It exists only for internal usage by the builders.
+func (m *CharacterTalentMutation) CharacterIDs() (ids []int) {
+	if id := m.character; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetCharacter resets all changes to the "character" edge.
+func (m *CharacterTalentMutation) ResetCharacter() {
+	m.character = nil
+	m.clearedcharacter = false
+}
+
+// SetTalentID sets the "talent" edge to the Talent entity by id.
+func (m *CharacterTalentMutation) SetTalentID(id int) {
+	m.talent = &id
+}
+
+// ClearTalent clears the "talent" edge to the Talent entity.
+func (m *CharacterTalentMutation) ClearTalent() {
+	m.clearedtalent = true
+}
+
+// TalentCleared reports if the "talent" edge to the Talent entity was cleared.
+func (m *CharacterTalentMutation) TalentCleared() bool {
+	return m.clearedtalent
+}
+
+// TalentID returns the "talent" edge ID in the mutation.
+func (m *CharacterTalentMutation) TalentID() (id int, exists bool) {
+	if m.talent != nil {
+		return *m.talent, true
+	}
+	return
+}
+
+// TalentIDs returns the "talent" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// TalentID instead. It exists only for internal usage by the builders.
+func (m *CharacterTalentMutation) TalentIDs() (ids []int) {
+	if id := m.talent; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetTalent resets all changes to the "talent" edge.
+func (m *CharacterTalentMutation) ResetTalent() {
+	m.talent = nil
+	m.clearedtalent = false
+}
+
+// Where appends a list predicates to the CharacterTalentMutation builder.
+func (m *CharacterTalentMutation) Where(ps ...predicate.CharacterTalent) {
+	m.predicates = append(m.predicates, ps...)
+}
+
+// WhereP appends storage-level predicates to the CharacterTalentMutation builder. Using this method,
+// users can use type-assertion to append predicates that do not depend on any generated package.
+func (m *CharacterTalentMutation) WhereP(ps ...func(*sql.Selector)) {
+	p := make([]predicate.CharacterTalent, len(ps))
+	for i := range ps {
+		p[i] = ps[i]
+	}
+	m.Where(p...)
+}
+
+// Op returns the operation name.
+func (m *CharacterTalentMutation) Op() Op {
+	return m.op
+}
+
+// SetOp allows setting the mutation operation.
+func (m *CharacterTalentMutation) SetOp(op Op) {
+	m.op = op
+}
+
+// Type returns the node type of this mutation (CharacterTalent).
+func (m *CharacterTalentMutation) Type() string {
+	return m.typ
+}
+
+// Fields returns all fields that were changed during this mutation. Note that in
+// order to get all numeric fields that were incremented/decremented, call
+// AddedFields().
+func (m *CharacterTalentMutation) Fields() []string {
+	fields := make([]string, 0, 1)
+	if m.slot != nil {
+		fields = append(fields, charactertalent.FieldSlot)
+	}
+	return fields
+}
+
+// Field returns the value of a field with the given name. The second boolean
+// return value indicates that this field was not set, or was not defined in the
+// schema.
+func (m *CharacterTalentMutation) Field(name string) (ent.Value, bool) {
+	switch name {
+	case charactertalent.FieldSlot:
+		return m.Slot()
+	}
+	return nil, false
+}
+
+// OldField returns the old value of the field from the database. An error is
+// returned if the mutation operation is not UpdateOne, or the query to the
+// database failed.
+func (m *CharacterTalentMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
+	switch name {
+	case charactertalent.FieldSlot:
+		return m.OldSlot(ctx)
+	}
+	return nil, fmt.Errorf("unknown CharacterTalent field %s", name)
+}
+
+// SetField sets the value of a field with the given name. It returns an error if
+// the field is not defined in the schema, or if the type mismatched the field
+// type.
+func (m *CharacterTalentMutation) SetField(name string, value ent.Value) error {
+	switch name {
+	case charactertalent.FieldSlot:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSlot(v)
+		return nil
+	}
+	return fmt.Errorf("unknown CharacterTalent field %s", name)
+}
+
+// AddedFields returns all numeric fields that were incremented/decremented during
+// this mutation.
+func (m *CharacterTalentMutation) AddedFields() []string {
+	var fields []string
+	if m.addslot != nil {
+		fields = append(fields, charactertalent.FieldSlot)
+	}
+	return fields
+}
+
+// AddedField returns the numeric value that was incremented/decremented on a field
+// with the given name. The second boolean return value indicates that this field
+// was not set, or was not defined in the schema.
+func (m *CharacterTalentMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	case charactertalent.FieldSlot:
+		return m.AddedSlot()
+	}
+	return nil, false
+}
+
+// AddField adds the value to the field with the given name. It returns an error if
+// the field is not defined in the schema, or if the type mismatched the field
+// type.
+func (m *CharacterTalentMutation) AddField(name string, value ent.Value) error {
+	switch name {
+	case charactertalent.FieldSlot:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddSlot(v)
+		return nil
+	}
+	return fmt.Errorf("unknown CharacterTalent numeric field %s", name)
+}
+
+// ClearedFields returns all nullable fields that were cleared during this
+// mutation.
+func (m *CharacterTalentMutation) ClearedFields() []string {
+	return nil
+}
+
+// FieldCleared returns a boolean indicating if a field with the given name was
+// cleared in this mutation.
+func (m *CharacterTalentMutation) FieldCleared(name string) bool {
+	_, ok := m.clearedFields[name]
+	return ok
+}
+
+// ClearField clears the value of the field with the given name. It returns an
+// error if the field is not defined in the schema.
+func (m *CharacterTalentMutation) ClearField(name string) error {
+	return fmt.Errorf("unknown CharacterTalent nullable field %s", name)
+}
+
+// ResetField resets all changes in the mutation for the field with the given name.
+// It returns an error if the field is not defined in the schema.
+func (m *CharacterTalentMutation) ResetField(name string) error {
+	switch name {
+	case charactertalent.FieldSlot:
+		m.ResetSlot()
+		return nil
+	}
+	return fmt.Errorf("unknown CharacterTalent field %s", name)
+}
+
+// AddedEdges returns all edge names that were set/added in this mutation.
+func (m *CharacterTalentMutation) AddedEdges() []string {
+	edges := make([]string, 0, 2)
+	if m.character != nil {
+		edges = append(edges, charactertalent.EdgeCharacter)
+	}
+	if m.talent != nil {
+		edges = append(edges, charactertalent.EdgeTalent)
+	}
+	return edges
+}
+
+// AddedIDs returns all IDs (to other nodes) that were added for the given edge
+// name in this mutation.
+func (m *CharacterTalentMutation) AddedIDs(name string) []ent.Value {
+	switch name {
+	case charactertalent.EdgeCharacter:
+		if id := m.character; id != nil {
+			return []ent.Value{*id}
+		}
+	case charactertalent.EdgeTalent:
+		if id := m.talent; id != nil {
+			return []ent.Value{*id}
+		}
+	}
+	return nil
+}
+
+// RemovedEdges returns all edge names that were removed in this mutation.
+func (m *CharacterTalentMutation) RemovedEdges() []string {
+	edges := make([]string, 0, 2)
+	return edges
+}
+
+// RemovedIDs returns all IDs (to other nodes) that were removed for the edge with
+// the given name in this mutation.
+func (m *CharacterTalentMutation) RemovedIDs(name string) []ent.Value {
+	return nil
+}
+
+// ClearedEdges returns all edge names that were cleared in this mutation.
+func (m *CharacterTalentMutation) ClearedEdges() []string {
+	edges := make([]string, 0, 2)
+	if m.clearedcharacter {
+		edges = append(edges, charactertalent.EdgeCharacter)
+	}
+	if m.clearedtalent {
+		edges = append(edges, charactertalent.EdgeTalent)
+	}
+	return edges
+}
+
+// EdgeCleared returns a boolean which indicates if the edge with the given name
+// was cleared in this mutation.
+func (m *CharacterTalentMutation) EdgeCleared(name string) bool {
+	switch name {
+	case charactertalent.EdgeCharacter:
+		return m.clearedcharacter
+	case charactertalent.EdgeTalent:
+		return m.clearedtalent
+	}
+	return false
+}
+
+// ClearEdge clears the value of the edge with the given name. It returns an error
+// if that edge is not defined in the schema.
+func (m *CharacterTalentMutation) ClearEdge(name string) error {
+	switch name {
+	case charactertalent.EdgeCharacter:
+		m.ClearCharacter()
+		return nil
+	case charactertalent.EdgeTalent:
+		m.ClearTalent()
+		return nil
+	}
+	return fmt.Errorf("unknown CharacterTalent unique edge %s", name)
+}
+
+// ResetEdge resets all changes to the edge with the given name in this mutation.
+// It returns an error if the edge is not defined in the schema.
+func (m *CharacterTalentMutation) ResetEdge(name string) error {
+	switch name {
+	case charactertalent.EdgeCharacter:
+		m.ResetCharacter()
+		return nil
+	case charactertalent.EdgeTalent:
+		m.ResetTalent()
+		return nil
+	}
+	return fmt.Errorf("unknown CharacterTalent edge %s", name)
 }
 
 // EquipmentMutation represents an operation that mutates the Equipment nodes in the graph.
@@ -5164,6 +7175,1418 @@ func (m *RoomMutation) ResetEdge(name string) error {
 		return nil
 	}
 	return fmt.Errorf("unknown Room edge %s", name)
+}
+
+// SkillMutation represents an operation that mutates the Skill nodes in the graph.
+type SkillMutation struct {
+	config
+	op                Op
+	typ               string
+	id                *int
+	name              *string
+	description       *string
+	skill_type        *string
+	cost              *int
+	addcost           *int
+	cooldown          *int
+	addcooldown       *int
+	requirements      *string
+	clearedFields     map[string]struct{}
+	characters        map[int]struct{}
+	removedcharacters map[int]struct{}
+	clearedcharacters bool
+	done              bool
+	oldValue          func(context.Context) (*Skill, error)
+	predicates        []predicate.Skill
+}
+
+var _ ent.Mutation = (*SkillMutation)(nil)
+
+// skillOption allows management of the mutation configuration using functional options.
+type skillOption func(*SkillMutation)
+
+// newSkillMutation creates new mutation for the Skill entity.
+func newSkillMutation(c config, op Op, opts ...skillOption) *SkillMutation {
+	m := &SkillMutation{
+		config:        c,
+		op:            op,
+		typ:           TypeSkill,
+		clearedFields: make(map[string]struct{}),
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// withSkillID sets the ID field of the mutation.
+func withSkillID(id int) skillOption {
+	return func(m *SkillMutation) {
+		var (
+			err   error
+			once  sync.Once
+			value *Skill
+		)
+		m.oldValue = func(ctx context.Context) (*Skill, error) {
+			once.Do(func() {
+				if m.done {
+					err = errors.New("querying old values post mutation is not allowed")
+				} else {
+					value, err = m.Client().Skill.Get(ctx, id)
+				}
+			})
+			return value, err
+		}
+		m.id = &id
+	}
+}
+
+// withSkill sets the old Skill of the mutation.
+func withSkill(node *Skill) skillOption {
+	return func(m *SkillMutation) {
+		m.oldValue = func(context.Context) (*Skill, error) {
+			return node, nil
+		}
+		m.id = &node.ID
+	}
+}
+
+// Client returns a new `ent.Client` from the mutation. If the mutation was
+// executed in a transaction (ent.Tx), a transactional client is returned.
+func (m SkillMutation) Client() *Client {
+	client := &Client{config: m.config}
+	client.init()
+	return client
+}
+
+// Tx returns an `ent.Tx` for mutations that were executed in transactions;
+// it returns an error otherwise.
+func (m SkillMutation) Tx() (*Tx, error) {
+	if _, ok := m.driver.(*txDriver); !ok {
+		return nil, errors.New("db: mutation is not running in a transaction")
+	}
+	tx := &Tx{config: m.config}
+	tx.init()
+	return tx, nil
+}
+
+// ID returns the ID value in the mutation. Note that the ID is only available
+// if it was provided to the builder or after it was returned from the database.
+func (m *SkillMutation) ID() (id int, exists bool) {
+	if m.id == nil {
+		return
+	}
+	return *m.id, true
+}
+
+// IDs queries the database and returns the entity ids that match the mutation's predicate.
+// That means, if the mutation is applied within a transaction with an isolation level such
+// as sql.LevelSerializable, the returned ids match the ids of the rows that will be updated
+// or updated by the mutation.
+func (m *SkillMutation) IDs(ctx context.Context) ([]int, error) {
+	switch {
+	case m.op.Is(OpUpdateOne | OpDeleteOne):
+		id, exists := m.ID()
+		if exists {
+			return []int{id}, nil
+		}
+		fallthrough
+	case m.op.Is(OpUpdate | OpDelete):
+		return m.Client().Skill.Query().Where(m.predicates...).IDs(ctx)
+	default:
+		return nil, fmt.Errorf("IDs is not allowed on %s operations", m.op)
+	}
+}
+
+// SetName sets the "name" field.
+func (m *SkillMutation) SetName(s string) {
+	m.name = &s
+}
+
+// Name returns the value of the "name" field in the mutation.
+func (m *SkillMutation) Name() (r string, exists bool) {
+	v := m.name
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldName returns the old "name" field's value of the Skill entity.
+// If the Skill object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SkillMutation) OldName(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldName is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldName requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldName: %w", err)
+	}
+	return oldValue.Name, nil
+}
+
+// ResetName resets all changes to the "name" field.
+func (m *SkillMutation) ResetName() {
+	m.name = nil
+}
+
+// SetDescription sets the "description" field.
+func (m *SkillMutation) SetDescription(s string) {
+	m.description = &s
+}
+
+// Description returns the value of the "description" field in the mutation.
+func (m *SkillMutation) Description() (r string, exists bool) {
+	v := m.description
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDescription returns the old "description" field's value of the Skill entity.
+// If the Skill object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SkillMutation) OldDescription(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDescription is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDescription requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDescription: %w", err)
+	}
+	return oldValue.Description, nil
+}
+
+// ResetDescription resets all changes to the "description" field.
+func (m *SkillMutation) ResetDescription() {
+	m.description = nil
+}
+
+// SetSkillType sets the "skill_type" field.
+func (m *SkillMutation) SetSkillType(s string) {
+	m.skill_type = &s
+}
+
+// SkillType returns the value of the "skill_type" field in the mutation.
+func (m *SkillMutation) SkillType() (r string, exists bool) {
+	v := m.skill_type
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSkillType returns the old "skill_type" field's value of the Skill entity.
+// If the Skill object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SkillMutation) OldSkillType(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSkillType is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSkillType requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSkillType: %w", err)
+	}
+	return oldValue.SkillType, nil
+}
+
+// ResetSkillType resets all changes to the "skill_type" field.
+func (m *SkillMutation) ResetSkillType() {
+	m.skill_type = nil
+}
+
+// SetCost sets the "cost" field.
+func (m *SkillMutation) SetCost(i int) {
+	m.cost = &i
+	m.addcost = nil
+}
+
+// Cost returns the value of the "cost" field in the mutation.
+func (m *SkillMutation) Cost() (r int, exists bool) {
+	v := m.cost
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCost returns the old "cost" field's value of the Skill entity.
+// If the Skill object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SkillMutation) OldCost(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCost is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCost requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCost: %w", err)
+	}
+	return oldValue.Cost, nil
+}
+
+// AddCost adds i to the "cost" field.
+func (m *SkillMutation) AddCost(i int) {
+	if m.addcost != nil {
+		*m.addcost += i
+	} else {
+		m.addcost = &i
+	}
+}
+
+// AddedCost returns the value that was added to the "cost" field in this mutation.
+func (m *SkillMutation) AddedCost() (r int, exists bool) {
+	v := m.addcost
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetCost resets all changes to the "cost" field.
+func (m *SkillMutation) ResetCost() {
+	m.cost = nil
+	m.addcost = nil
+}
+
+// SetCooldown sets the "cooldown" field.
+func (m *SkillMutation) SetCooldown(i int) {
+	m.cooldown = &i
+	m.addcooldown = nil
+}
+
+// Cooldown returns the value of the "cooldown" field in the mutation.
+func (m *SkillMutation) Cooldown() (r int, exists bool) {
+	v := m.cooldown
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCooldown returns the old "cooldown" field's value of the Skill entity.
+// If the Skill object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SkillMutation) OldCooldown(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCooldown is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCooldown requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCooldown: %w", err)
+	}
+	return oldValue.Cooldown, nil
+}
+
+// AddCooldown adds i to the "cooldown" field.
+func (m *SkillMutation) AddCooldown(i int) {
+	if m.addcooldown != nil {
+		*m.addcooldown += i
+	} else {
+		m.addcooldown = &i
+	}
+}
+
+// AddedCooldown returns the value that was added to the "cooldown" field in this mutation.
+func (m *SkillMutation) AddedCooldown() (r int, exists bool) {
+	v := m.addcooldown
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetCooldown resets all changes to the "cooldown" field.
+func (m *SkillMutation) ResetCooldown() {
+	m.cooldown = nil
+	m.addcooldown = nil
+}
+
+// SetRequirements sets the "requirements" field.
+func (m *SkillMutation) SetRequirements(s string) {
+	m.requirements = &s
+}
+
+// Requirements returns the value of the "requirements" field in the mutation.
+func (m *SkillMutation) Requirements() (r string, exists bool) {
+	v := m.requirements
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRequirements returns the old "requirements" field's value of the Skill entity.
+// If the Skill object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SkillMutation) OldRequirements(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRequirements is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRequirements requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRequirements: %w", err)
+	}
+	return oldValue.Requirements, nil
+}
+
+// ClearRequirements clears the value of the "requirements" field.
+func (m *SkillMutation) ClearRequirements() {
+	m.requirements = nil
+	m.clearedFields[skill.FieldRequirements] = struct{}{}
+}
+
+// RequirementsCleared returns if the "requirements" field was cleared in this mutation.
+func (m *SkillMutation) RequirementsCleared() bool {
+	_, ok := m.clearedFields[skill.FieldRequirements]
+	return ok
+}
+
+// ResetRequirements resets all changes to the "requirements" field.
+func (m *SkillMutation) ResetRequirements() {
+	m.requirements = nil
+	delete(m.clearedFields, skill.FieldRequirements)
+}
+
+// AddCharacterIDs adds the "characters" edge to the CharacterSkill entity by ids.
+func (m *SkillMutation) AddCharacterIDs(ids ...int) {
+	if m.characters == nil {
+		m.characters = make(map[int]struct{})
+	}
+	for i := range ids {
+		m.characters[ids[i]] = struct{}{}
+	}
+}
+
+// ClearCharacters clears the "characters" edge to the CharacterSkill entity.
+func (m *SkillMutation) ClearCharacters() {
+	m.clearedcharacters = true
+}
+
+// CharactersCleared reports if the "characters" edge to the CharacterSkill entity was cleared.
+func (m *SkillMutation) CharactersCleared() bool {
+	return m.clearedcharacters
+}
+
+// RemoveCharacterIDs removes the "characters" edge to the CharacterSkill entity by IDs.
+func (m *SkillMutation) RemoveCharacterIDs(ids ...int) {
+	if m.removedcharacters == nil {
+		m.removedcharacters = make(map[int]struct{})
+	}
+	for i := range ids {
+		delete(m.characters, ids[i])
+		m.removedcharacters[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedCharacters returns the removed IDs of the "characters" edge to the CharacterSkill entity.
+func (m *SkillMutation) RemovedCharactersIDs() (ids []int) {
+	for id := range m.removedcharacters {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// CharactersIDs returns the "characters" edge IDs in the mutation.
+func (m *SkillMutation) CharactersIDs() (ids []int) {
+	for id := range m.characters {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetCharacters resets all changes to the "characters" edge.
+func (m *SkillMutation) ResetCharacters() {
+	m.characters = nil
+	m.clearedcharacters = false
+	m.removedcharacters = nil
+}
+
+// Where appends a list predicates to the SkillMutation builder.
+func (m *SkillMutation) Where(ps ...predicate.Skill) {
+	m.predicates = append(m.predicates, ps...)
+}
+
+// WhereP appends storage-level predicates to the SkillMutation builder. Using this method,
+// users can use type-assertion to append predicates that do not depend on any generated package.
+func (m *SkillMutation) WhereP(ps ...func(*sql.Selector)) {
+	p := make([]predicate.Skill, len(ps))
+	for i := range ps {
+		p[i] = ps[i]
+	}
+	m.Where(p...)
+}
+
+// Op returns the operation name.
+func (m *SkillMutation) Op() Op {
+	return m.op
+}
+
+// SetOp allows setting the mutation operation.
+func (m *SkillMutation) SetOp(op Op) {
+	m.op = op
+}
+
+// Type returns the node type of this mutation (Skill).
+func (m *SkillMutation) Type() string {
+	return m.typ
+}
+
+// Fields returns all fields that were changed during this mutation. Note that in
+// order to get all numeric fields that were incremented/decremented, call
+// AddedFields().
+func (m *SkillMutation) Fields() []string {
+	fields := make([]string, 0, 6)
+	if m.name != nil {
+		fields = append(fields, skill.FieldName)
+	}
+	if m.description != nil {
+		fields = append(fields, skill.FieldDescription)
+	}
+	if m.skill_type != nil {
+		fields = append(fields, skill.FieldSkillType)
+	}
+	if m.cost != nil {
+		fields = append(fields, skill.FieldCost)
+	}
+	if m.cooldown != nil {
+		fields = append(fields, skill.FieldCooldown)
+	}
+	if m.requirements != nil {
+		fields = append(fields, skill.FieldRequirements)
+	}
+	return fields
+}
+
+// Field returns the value of a field with the given name. The second boolean
+// return value indicates that this field was not set, or was not defined in the
+// schema.
+func (m *SkillMutation) Field(name string) (ent.Value, bool) {
+	switch name {
+	case skill.FieldName:
+		return m.Name()
+	case skill.FieldDescription:
+		return m.Description()
+	case skill.FieldSkillType:
+		return m.SkillType()
+	case skill.FieldCost:
+		return m.Cost()
+	case skill.FieldCooldown:
+		return m.Cooldown()
+	case skill.FieldRequirements:
+		return m.Requirements()
+	}
+	return nil, false
+}
+
+// OldField returns the old value of the field from the database. An error is
+// returned if the mutation operation is not UpdateOne, or the query to the
+// database failed.
+func (m *SkillMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
+	switch name {
+	case skill.FieldName:
+		return m.OldName(ctx)
+	case skill.FieldDescription:
+		return m.OldDescription(ctx)
+	case skill.FieldSkillType:
+		return m.OldSkillType(ctx)
+	case skill.FieldCost:
+		return m.OldCost(ctx)
+	case skill.FieldCooldown:
+		return m.OldCooldown(ctx)
+	case skill.FieldRequirements:
+		return m.OldRequirements(ctx)
+	}
+	return nil, fmt.Errorf("unknown Skill field %s", name)
+}
+
+// SetField sets the value of a field with the given name. It returns an error if
+// the field is not defined in the schema, or if the type mismatched the field
+// type.
+func (m *SkillMutation) SetField(name string, value ent.Value) error {
+	switch name {
+	case skill.FieldName:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetName(v)
+		return nil
+	case skill.FieldDescription:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDescription(v)
+		return nil
+	case skill.FieldSkillType:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSkillType(v)
+		return nil
+	case skill.FieldCost:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCost(v)
+		return nil
+	case skill.FieldCooldown:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCooldown(v)
+		return nil
+	case skill.FieldRequirements:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRequirements(v)
+		return nil
+	}
+	return fmt.Errorf("unknown Skill field %s", name)
+}
+
+// AddedFields returns all numeric fields that were incremented/decremented during
+// this mutation.
+func (m *SkillMutation) AddedFields() []string {
+	var fields []string
+	if m.addcost != nil {
+		fields = append(fields, skill.FieldCost)
+	}
+	if m.addcooldown != nil {
+		fields = append(fields, skill.FieldCooldown)
+	}
+	return fields
+}
+
+// AddedField returns the numeric value that was incremented/decremented on a field
+// with the given name. The second boolean return value indicates that this field
+// was not set, or was not defined in the schema.
+func (m *SkillMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	case skill.FieldCost:
+		return m.AddedCost()
+	case skill.FieldCooldown:
+		return m.AddedCooldown()
+	}
+	return nil, false
+}
+
+// AddField adds the value to the field with the given name. It returns an error if
+// the field is not defined in the schema, or if the type mismatched the field
+// type.
+func (m *SkillMutation) AddField(name string, value ent.Value) error {
+	switch name {
+	case skill.FieldCost:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddCost(v)
+		return nil
+	case skill.FieldCooldown:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddCooldown(v)
+		return nil
+	}
+	return fmt.Errorf("unknown Skill numeric field %s", name)
+}
+
+// ClearedFields returns all nullable fields that were cleared during this
+// mutation.
+func (m *SkillMutation) ClearedFields() []string {
+	var fields []string
+	if m.FieldCleared(skill.FieldRequirements) {
+		fields = append(fields, skill.FieldRequirements)
+	}
+	return fields
+}
+
+// FieldCleared returns a boolean indicating if a field with the given name was
+// cleared in this mutation.
+func (m *SkillMutation) FieldCleared(name string) bool {
+	_, ok := m.clearedFields[name]
+	return ok
+}
+
+// ClearField clears the value of the field with the given name. It returns an
+// error if the field is not defined in the schema.
+func (m *SkillMutation) ClearField(name string) error {
+	switch name {
+	case skill.FieldRequirements:
+		m.ClearRequirements()
+		return nil
+	}
+	return fmt.Errorf("unknown Skill nullable field %s", name)
+}
+
+// ResetField resets all changes in the mutation for the field with the given name.
+// It returns an error if the field is not defined in the schema.
+func (m *SkillMutation) ResetField(name string) error {
+	switch name {
+	case skill.FieldName:
+		m.ResetName()
+		return nil
+	case skill.FieldDescription:
+		m.ResetDescription()
+		return nil
+	case skill.FieldSkillType:
+		m.ResetSkillType()
+		return nil
+	case skill.FieldCost:
+		m.ResetCost()
+		return nil
+	case skill.FieldCooldown:
+		m.ResetCooldown()
+		return nil
+	case skill.FieldRequirements:
+		m.ResetRequirements()
+		return nil
+	}
+	return fmt.Errorf("unknown Skill field %s", name)
+}
+
+// AddedEdges returns all edge names that were set/added in this mutation.
+func (m *SkillMutation) AddedEdges() []string {
+	edges := make([]string, 0, 1)
+	if m.characters != nil {
+		edges = append(edges, skill.EdgeCharacters)
+	}
+	return edges
+}
+
+// AddedIDs returns all IDs (to other nodes) that were added for the given edge
+// name in this mutation.
+func (m *SkillMutation) AddedIDs(name string) []ent.Value {
+	switch name {
+	case skill.EdgeCharacters:
+		ids := make([]ent.Value, 0, len(m.characters))
+		for id := range m.characters {
+			ids = append(ids, id)
+		}
+		return ids
+	}
+	return nil
+}
+
+// RemovedEdges returns all edge names that were removed in this mutation.
+func (m *SkillMutation) RemovedEdges() []string {
+	edges := make([]string, 0, 1)
+	if m.removedcharacters != nil {
+		edges = append(edges, skill.EdgeCharacters)
+	}
+	return edges
+}
+
+// RemovedIDs returns all IDs (to other nodes) that were removed for the edge with
+// the given name in this mutation.
+func (m *SkillMutation) RemovedIDs(name string) []ent.Value {
+	switch name {
+	case skill.EdgeCharacters:
+		ids := make([]ent.Value, 0, len(m.removedcharacters))
+		for id := range m.removedcharacters {
+			ids = append(ids, id)
+		}
+		return ids
+	}
+	return nil
+}
+
+// ClearedEdges returns all edge names that were cleared in this mutation.
+func (m *SkillMutation) ClearedEdges() []string {
+	edges := make([]string, 0, 1)
+	if m.clearedcharacters {
+		edges = append(edges, skill.EdgeCharacters)
+	}
+	return edges
+}
+
+// EdgeCleared returns a boolean which indicates if the edge with the given name
+// was cleared in this mutation.
+func (m *SkillMutation) EdgeCleared(name string) bool {
+	switch name {
+	case skill.EdgeCharacters:
+		return m.clearedcharacters
+	}
+	return false
+}
+
+// ClearEdge clears the value of the edge with the given name. It returns an error
+// if that edge is not defined in the schema.
+func (m *SkillMutation) ClearEdge(name string) error {
+	switch name {
+	}
+	return fmt.Errorf("unknown Skill unique edge %s", name)
+}
+
+// ResetEdge resets all changes to the edge with the given name in this mutation.
+// It returns an error if the edge is not defined in the schema.
+func (m *SkillMutation) ResetEdge(name string) error {
+	switch name {
+	case skill.EdgeCharacters:
+		m.ResetCharacters()
+		return nil
+	}
+	return fmt.Errorf("unknown Skill edge %s", name)
+}
+
+// TalentMutation represents an operation that mutates the Talent nodes in the graph.
+type TalentMutation struct {
+	config
+	op                             Op
+	typ                            string
+	id                             *int
+	name                           *string
+	description                    *string
+	requirements                   *string
+	clearedFields                  map[string]struct{}
+	characters                     map[int]struct{}
+	removedcharacters              map[int]struct{}
+	clearedcharacters              bool
+	available_to_characters        map[int]struct{}
+	removedavailable_to_characters map[int]struct{}
+	clearedavailable_to_characters bool
+	done                           bool
+	oldValue                       func(context.Context) (*Talent, error)
+	predicates                     []predicate.Talent
+}
+
+var _ ent.Mutation = (*TalentMutation)(nil)
+
+// talentOption allows management of the mutation configuration using functional options.
+type talentOption func(*TalentMutation)
+
+// newTalentMutation creates new mutation for the Talent entity.
+func newTalentMutation(c config, op Op, opts ...talentOption) *TalentMutation {
+	m := &TalentMutation{
+		config:        c,
+		op:            op,
+		typ:           TypeTalent,
+		clearedFields: make(map[string]struct{}),
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// withTalentID sets the ID field of the mutation.
+func withTalentID(id int) talentOption {
+	return func(m *TalentMutation) {
+		var (
+			err   error
+			once  sync.Once
+			value *Talent
+		)
+		m.oldValue = func(ctx context.Context) (*Talent, error) {
+			once.Do(func() {
+				if m.done {
+					err = errors.New("querying old values post mutation is not allowed")
+				} else {
+					value, err = m.Client().Talent.Get(ctx, id)
+				}
+			})
+			return value, err
+		}
+		m.id = &id
+	}
+}
+
+// withTalent sets the old Talent of the mutation.
+func withTalent(node *Talent) talentOption {
+	return func(m *TalentMutation) {
+		m.oldValue = func(context.Context) (*Talent, error) {
+			return node, nil
+		}
+		m.id = &node.ID
+	}
+}
+
+// Client returns a new `ent.Client` from the mutation. If the mutation was
+// executed in a transaction (ent.Tx), a transactional client is returned.
+func (m TalentMutation) Client() *Client {
+	client := &Client{config: m.config}
+	client.init()
+	return client
+}
+
+// Tx returns an `ent.Tx` for mutations that were executed in transactions;
+// it returns an error otherwise.
+func (m TalentMutation) Tx() (*Tx, error) {
+	if _, ok := m.driver.(*txDriver); !ok {
+		return nil, errors.New("db: mutation is not running in a transaction")
+	}
+	tx := &Tx{config: m.config}
+	tx.init()
+	return tx, nil
+}
+
+// ID returns the ID value in the mutation. Note that the ID is only available
+// if it was provided to the builder or after it was returned from the database.
+func (m *TalentMutation) ID() (id int, exists bool) {
+	if m.id == nil {
+		return
+	}
+	return *m.id, true
+}
+
+// IDs queries the database and returns the entity ids that match the mutation's predicate.
+// That means, if the mutation is applied within a transaction with an isolation level such
+// as sql.LevelSerializable, the returned ids match the ids of the rows that will be updated
+// or updated by the mutation.
+func (m *TalentMutation) IDs(ctx context.Context) ([]int, error) {
+	switch {
+	case m.op.Is(OpUpdateOne | OpDeleteOne):
+		id, exists := m.ID()
+		if exists {
+			return []int{id}, nil
+		}
+		fallthrough
+	case m.op.Is(OpUpdate | OpDelete):
+		return m.Client().Talent.Query().Where(m.predicates...).IDs(ctx)
+	default:
+		return nil, fmt.Errorf("IDs is not allowed on %s operations", m.op)
+	}
+}
+
+// SetName sets the "name" field.
+func (m *TalentMutation) SetName(s string) {
+	m.name = &s
+}
+
+// Name returns the value of the "name" field in the mutation.
+func (m *TalentMutation) Name() (r string, exists bool) {
+	v := m.name
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldName returns the old "name" field's value of the Talent entity.
+// If the Talent object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TalentMutation) OldName(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldName is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldName requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldName: %w", err)
+	}
+	return oldValue.Name, nil
+}
+
+// ResetName resets all changes to the "name" field.
+func (m *TalentMutation) ResetName() {
+	m.name = nil
+}
+
+// SetDescription sets the "description" field.
+func (m *TalentMutation) SetDescription(s string) {
+	m.description = &s
+}
+
+// Description returns the value of the "description" field in the mutation.
+func (m *TalentMutation) Description() (r string, exists bool) {
+	v := m.description
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDescription returns the old "description" field's value of the Talent entity.
+// If the Talent object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TalentMutation) OldDescription(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDescription is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDescription requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDescription: %w", err)
+	}
+	return oldValue.Description, nil
+}
+
+// ResetDescription resets all changes to the "description" field.
+func (m *TalentMutation) ResetDescription() {
+	m.description = nil
+}
+
+// SetRequirements sets the "requirements" field.
+func (m *TalentMutation) SetRequirements(s string) {
+	m.requirements = &s
+}
+
+// Requirements returns the value of the "requirements" field in the mutation.
+func (m *TalentMutation) Requirements() (r string, exists bool) {
+	v := m.requirements
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRequirements returns the old "requirements" field's value of the Talent entity.
+// If the Talent object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TalentMutation) OldRequirements(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRequirements is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRequirements requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRequirements: %w", err)
+	}
+	return oldValue.Requirements, nil
+}
+
+// ClearRequirements clears the value of the "requirements" field.
+func (m *TalentMutation) ClearRequirements() {
+	m.requirements = nil
+	m.clearedFields[talent.FieldRequirements] = struct{}{}
+}
+
+// RequirementsCleared returns if the "requirements" field was cleared in this mutation.
+func (m *TalentMutation) RequirementsCleared() bool {
+	_, ok := m.clearedFields[talent.FieldRequirements]
+	return ok
+}
+
+// ResetRequirements resets all changes to the "requirements" field.
+func (m *TalentMutation) ResetRequirements() {
+	m.requirements = nil
+	delete(m.clearedFields, talent.FieldRequirements)
+}
+
+// AddCharacterIDs adds the "characters" edge to the CharacterTalent entity by ids.
+func (m *TalentMutation) AddCharacterIDs(ids ...int) {
+	if m.characters == nil {
+		m.characters = make(map[int]struct{})
+	}
+	for i := range ids {
+		m.characters[ids[i]] = struct{}{}
+	}
+}
+
+// ClearCharacters clears the "characters" edge to the CharacterTalent entity.
+func (m *TalentMutation) ClearCharacters() {
+	m.clearedcharacters = true
+}
+
+// CharactersCleared reports if the "characters" edge to the CharacterTalent entity was cleared.
+func (m *TalentMutation) CharactersCleared() bool {
+	return m.clearedcharacters
+}
+
+// RemoveCharacterIDs removes the "characters" edge to the CharacterTalent entity by IDs.
+func (m *TalentMutation) RemoveCharacterIDs(ids ...int) {
+	if m.removedcharacters == nil {
+		m.removedcharacters = make(map[int]struct{})
+	}
+	for i := range ids {
+		delete(m.characters, ids[i])
+		m.removedcharacters[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedCharacters returns the removed IDs of the "characters" edge to the CharacterTalent entity.
+func (m *TalentMutation) RemovedCharactersIDs() (ids []int) {
+	for id := range m.removedcharacters {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// CharactersIDs returns the "characters" edge IDs in the mutation.
+func (m *TalentMutation) CharactersIDs() (ids []int) {
+	for id := range m.characters {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetCharacters resets all changes to the "characters" edge.
+func (m *TalentMutation) ResetCharacters() {
+	m.characters = nil
+	m.clearedcharacters = false
+	m.removedcharacters = nil
+}
+
+// AddAvailableToCharacterIDs adds the "available_to_characters" edge to the AvailableTalent entity by ids.
+func (m *TalentMutation) AddAvailableToCharacterIDs(ids ...int) {
+	if m.available_to_characters == nil {
+		m.available_to_characters = make(map[int]struct{})
+	}
+	for i := range ids {
+		m.available_to_characters[ids[i]] = struct{}{}
+	}
+}
+
+// ClearAvailableToCharacters clears the "available_to_characters" edge to the AvailableTalent entity.
+func (m *TalentMutation) ClearAvailableToCharacters() {
+	m.clearedavailable_to_characters = true
+}
+
+// AvailableToCharactersCleared reports if the "available_to_characters" edge to the AvailableTalent entity was cleared.
+func (m *TalentMutation) AvailableToCharactersCleared() bool {
+	return m.clearedavailable_to_characters
+}
+
+// RemoveAvailableToCharacterIDs removes the "available_to_characters" edge to the AvailableTalent entity by IDs.
+func (m *TalentMutation) RemoveAvailableToCharacterIDs(ids ...int) {
+	if m.removedavailable_to_characters == nil {
+		m.removedavailable_to_characters = make(map[int]struct{})
+	}
+	for i := range ids {
+		delete(m.available_to_characters, ids[i])
+		m.removedavailable_to_characters[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedAvailableToCharacters returns the removed IDs of the "available_to_characters" edge to the AvailableTalent entity.
+func (m *TalentMutation) RemovedAvailableToCharactersIDs() (ids []int) {
+	for id := range m.removedavailable_to_characters {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// AvailableToCharactersIDs returns the "available_to_characters" edge IDs in the mutation.
+func (m *TalentMutation) AvailableToCharactersIDs() (ids []int) {
+	for id := range m.available_to_characters {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetAvailableToCharacters resets all changes to the "available_to_characters" edge.
+func (m *TalentMutation) ResetAvailableToCharacters() {
+	m.available_to_characters = nil
+	m.clearedavailable_to_characters = false
+	m.removedavailable_to_characters = nil
+}
+
+// Where appends a list predicates to the TalentMutation builder.
+func (m *TalentMutation) Where(ps ...predicate.Talent) {
+	m.predicates = append(m.predicates, ps...)
+}
+
+// WhereP appends storage-level predicates to the TalentMutation builder. Using this method,
+// users can use type-assertion to append predicates that do not depend on any generated package.
+func (m *TalentMutation) WhereP(ps ...func(*sql.Selector)) {
+	p := make([]predicate.Talent, len(ps))
+	for i := range ps {
+		p[i] = ps[i]
+	}
+	m.Where(p...)
+}
+
+// Op returns the operation name.
+func (m *TalentMutation) Op() Op {
+	return m.op
+}
+
+// SetOp allows setting the mutation operation.
+func (m *TalentMutation) SetOp(op Op) {
+	m.op = op
+}
+
+// Type returns the node type of this mutation (Talent).
+func (m *TalentMutation) Type() string {
+	return m.typ
+}
+
+// Fields returns all fields that were changed during this mutation. Note that in
+// order to get all numeric fields that were incremented/decremented, call
+// AddedFields().
+func (m *TalentMutation) Fields() []string {
+	fields := make([]string, 0, 3)
+	if m.name != nil {
+		fields = append(fields, talent.FieldName)
+	}
+	if m.description != nil {
+		fields = append(fields, talent.FieldDescription)
+	}
+	if m.requirements != nil {
+		fields = append(fields, talent.FieldRequirements)
+	}
+	return fields
+}
+
+// Field returns the value of a field with the given name. The second boolean
+// return value indicates that this field was not set, or was not defined in the
+// schema.
+func (m *TalentMutation) Field(name string) (ent.Value, bool) {
+	switch name {
+	case talent.FieldName:
+		return m.Name()
+	case talent.FieldDescription:
+		return m.Description()
+	case talent.FieldRequirements:
+		return m.Requirements()
+	}
+	return nil, false
+}
+
+// OldField returns the old value of the field from the database. An error is
+// returned if the mutation operation is not UpdateOne, or the query to the
+// database failed.
+func (m *TalentMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
+	switch name {
+	case talent.FieldName:
+		return m.OldName(ctx)
+	case talent.FieldDescription:
+		return m.OldDescription(ctx)
+	case talent.FieldRequirements:
+		return m.OldRequirements(ctx)
+	}
+	return nil, fmt.Errorf("unknown Talent field %s", name)
+}
+
+// SetField sets the value of a field with the given name. It returns an error if
+// the field is not defined in the schema, or if the type mismatched the field
+// type.
+func (m *TalentMutation) SetField(name string, value ent.Value) error {
+	switch name {
+	case talent.FieldName:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetName(v)
+		return nil
+	case talent.FieldDescription:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDescription(v)
+		return nil
+	case talent.FieldRequirements:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRequirements(v)
+		return nil
+	}
+	return fmt.Errorf("unknown Talent field %s", name)
+}
+
+// AddedFields returns all numeric fields that were incremented/decremented during
+// this mutation.
+func (m *TalentMutation) AddedFields() []string {
+	return nil
+}
+
+// AddedField returns the numeric value that was incremented/decremented on a field
+// with the given name. The second boolean return value indicates that this field
+// was not set, or was not defined in the schema.
+func (m *TalentMutation) AddedField(name string) (ent.Value, bool) {
+	return nil, false
+}
+
+// AddField adds the value to the field with the given name. It returns an error if
+// the field is not defined in the schema, or if the type mismatched the field
+// type.
+func (m *TalentMutation) AddField(name string, value ent.Value) error {
+	switch name {
+	}
+	return fmt.Errorf("unknown Talent numeric field %s", name)
+}
+
+// ClearedFields returns all nullable fields that were cleared during this
+// mutation.
+func (m *TalentMutation) ClearedFields() []string {
+	var fields []string
+	if m.FieldCleared(talent.FieldRequirements) {
+		fields = append(fields, talent.FieldRequirements)
+	}
+	return fields
+}
+
+// FieldCleared returns a boolean indicating if a field with the given name was
+// cleared in this mutation.
+func (m *TalentMutation) FieldCleared(name string) bool {
+	_, ok := m.clearedFields[name]
+	return ok
+}
+
+// ClearField clears the value of the field with the given name. It returns an
+// error if the field is not defined in the schema.
+func (m *TalentMutation) ClearField(name string) error {
+	switch name {
+	case talent.FieldRequirements:
+		m.ClearRequirements()
+		return nil
+	}
+	return fmt.Errorf("unknown Talent nullable field %s", name)
+}
+
+// ResetField resets all changes in the mutation for the field with the given name.
+// It returns an error if the field is not defined in the schema.
+func (m *TalentMutation) ResetField(name string) error {
+	switch name {
+	case talent.FieldName:
+		m.ResetName()
+		return nil
+	case talent.FieldDescription:
+		m.ResetDescription()
+		return nil
+	case talent.FieldRequirements:
+		m.ResetRequirements()
+		return nil
+	}
+	return fmt.Errorf("unknown Talent field %s", name)
+}
+
+// AddedEdges returns all edge names that were set/added in this mutation.
+func (m *TalentMutation) AddedEdges() []string {
+	edges := make([]string, 0, 2)
+	if m.characters != nil {
+		edges = append(edges, talent.EdgeCharacters)
+	}
+	if m.available_to_characters != nil {
+		edges = append(edges, talent.EdgeAvailableToCharacters)
+	}
+	return edges
+}
+
+// AddedIDs returns all IDs (to other nodes) that were added for the given edge
+// name in this mutation.
+func (m *TalentMutation) AddedIDs(name string) []ent.Value {
+	switch name {
+	case talent.EdgeCharacters:
+		ids := make([]ent.Value, 0, len(m.characters))
+		for id := range m.characters {
+			ids = append(ids, id)
+		}
+		return ids
+	case talent.EdgeAvailableToCharacters:
+		ids := make([]ent.Value, 0, len(m.available_to_characters))
+		for id := range m.available_to_characters {
+			ids = append(ids, id)
+		}
+		return ids
+	}
+	return nil
+}
+
+// RemovedEdges returns all edge names that were removed in this mutation.
+func (m *TalentMutation) RemovedEdges() []string {
+	edges := make([]string, 0, 2)
+	if m.removedcharacters != nil {
+		edges = append(edges, talent.EdgeCharacters)
+	}
+	if m.removedavailable_to_characters != nil {
+		edges = append(edges, talent.EdgeAvailableToCharacters)
+	}
+	return edges
+}
+
+// RemovedIDs returns all IDs (to other nodes) that were removed for the edge with
+// the given name in this mutation.
+func (m *TalentMutation) RemovedIDs(name string) []ent.Value {
+	switch name {
+	case talent.EdgeCharacters:
+		ids := make([]ent.Value, 0, len(m.removedcharacters))
+		for id := range m.removedcharacters {
+			ids = append(ids, id)
+		}
+		return ids
+	case talent.EdgeAvailableToCharacters:
+		ids := make([]ent.Value, 0, len(m.removedavailable_to_characters))
+		for id := range m.removedavailable_to_characters {
+			ids = append(ids, id)
+		}
+		return ids
+	}
+	return nil
+}
+
+// ClearedEdges returns all edge names that were cleared in this mutation.
+func (m *TalentMutation) ClearedEdges() []string {
+	edges := make([]string, 0, 2)
+	if m.clearedcharacters {
+		edges = append(edges, talent.EdgeCharacters)
+	}
+	if m.clearedavailable_to_characters {
+		edges = append(edges, talent.EdgeAvailableToCharacters)
+	}
+	return edges
+}
+
+// EdgeCleared returns a boolean which indicates if the edge with the given name
+// was cleared in this mutation.
+func (m *TalentMutation) EdgeCleared(name string) bool {
+	switch name {
+	case talent.EdgeCharacters:
+		return m.clearedcharacters
+	case talent.EdgeAvailableToCharacters:
+		return m.clearedavailable_to_characters
+	}
+	return false
+}
+
+// ClearEdge clears the value of the edge with the given name. It returns an error
+// if that edge is not defined in the schema.
+func (m *TalentMutation) ClearEdge(name string) error {
+	switch name {
+	}
+	return fmt.Errorf("unknown Talent unique edge %s", name)
+}
+
+// ResetEdge resets all changes to the edge with the given name in this mutation.
+// It returns an error if the edge is not defined in the schema.
+func (m *TalentMutation) ResetEdge(name string) error {
+	switch name {
+	case talent.EdgeCharacters:
+		m.ResetCharacters()
+		return nil
+	case talent.EdgeAvailableToCharacters:
+		m.ResetAvailableToCharacters()
+		return nil
+	}
+	return fmt.Errorf("unknown Talent edge %s", name)
 }
 
 // UserMutation represents an operation that mutates the User nodes in the graph.

--- a/server/db/runtime.go
+++ b/server/db/runtime.go
@@ -3,7 +3,10 @@
 package db
 
 import (
+	"herbst-server/db/availabletalent"
 	"herbst-server/db/character"
+	"herbst-server/db/characterskill"
+	"herbst-server/db/charactertalent"
 	"herbst-server/db/equipment"
 	"herbst-server/db/npctemplate"
 	"herbst-server/db/room"
@@ -16,6 +19,16 @@ import (
 // (default values, validators, hooks and policies) and stitches it
 // to their package variables.
 func init() {
+	availabletalentFields := schema.AvailableTalent{}.Fields()
+	_ = availabletalentFields
+	// availabletalentDescUnlockReason is the schema descriptor for unlock_reason field.
+	availabletalentDescUnlockReason := availabletalentFields[0].Descriptor()
+	// availabletalent.DefaultUnlockReason holds the default value on creation for the unlock_reason field.
+	availabletalent.DefaultUnlockReason = availabletalentDescUnlockReason.Default.(string)
+	// availabletalentDescUnlockedAtLevel is the schema descriptor for unlocked_at_level field.
+	availabletalentDescUnlockedAtLevel := availabletalentFields[1].Descriptor()
+	// availabletalent.DefaultUnlockedAtLevel holds the default value on creation for the unlocked_at_level field.
+	availabletalent.DefaultUnlockedAtLevel = availabletalentDescUnlockedAtLevel.Default.(int)
 	characterFields := schema.Character{}.Fields()
 	_ = characterFields
 	// characterDescIsNPC is the schema descriptor for isNPC field.
@@ -59,65 +72,81 @@ func init() {
 	// character.DefaultClass holds the default value on creation for the class field.
 	character.DefaultClass = characterDescClass.Default.(string)
 	// characterDescLevel is the schema descriptor for level field.
-	characterDescLevel := characterFields[14].Descriptor()
+	characterDescLevel := characterFields[15].Descriptor()
 	// character.DefaultLevel holds the default value on creation for the level field.
 	character.DefaultLevel = characterDescLevel.Default.(int)
 	// characterDescConstitution is the schema descriptor for constitution field.
-	characterDescConstitution := characterFields[15].Descriptor()
+	characterDescConstitution := characterFields[16].Descriptor()
 	// character.DefaultConstitution holds the default value on creation for the constitution field.
 	character.DefaultConstitution = characterDescConstitution.Default.(int)
 	// characterDescStrength is the schema descriptor for strength field.
-	characterDescStrength := characterFields[18].Descriptor()
+	characterDescStrength := characterFields[19].Descriptor()
 	// character.DefaultStrength holds the default value on creation for the strength field.
 	character.DefaultStrength = characterDescStrength.Default.(int)
 	// characterDescDexterity is the schema descriptor for dexterity field.
-	characterDescDexterity := characterFields[19].Descriptor()
+	characterDescDexterity := characterFields[20].Descriptor()
 	// character.DefaultDexterity holds the default value on creation for the dexterity field.
 	character.DefaultDexterity = characterDescDexterity.Default.(int)
 	// characterDescIntelligence is the schema descriptor for intelligence field.
-	characterDescIntelligence := characterFields[20].Descriptor()
+	characterDescIntelligence := characterFields[21].Descriptor()
 	// character.DefaultIntelligence holds the default value on creation for the intelligence field.
 	character.DefaultIntelligence = characterDescIntelligence.Default.(int)
 	// characterDescWisdom is the schema descriptor for wisdom field.
-	characterDescWisdom := characterFields[21].Descriptor()
+	characterDescWisdom := characterFields[22].Descriptor()
 	// character.DefaultWisdom holds the default value on creation for the wisdom field.
 	character.DefaultWisdom = characterDescWisdom.Default.(int)
 	// characterDescSkillBlades is the schema descriptor for skill_blades field.
-	characterDescSkillBlades := characterFields[22].Descriptor()
+	characterDescSkillBlades := characterFields[23].Descriptor()
 	// character.DefaultSkillBlades holds the default value on creation for the skill_blades field.
 	character.DefaultSkillBlades = characterDescSkillBlades.Default.(int)
 	// characterDescSkillStaves is the schema descriptor for skill_staves field.
-	characterDescSkillStaves := characterFields[23].Descriptor()
+	characterDescSkillStaves := characterFields[24].Descriptor()
 	// character.DefaultSkillStaves holds the default value on creation for the skill_staves field.
 	character.DefaultSkillStaves = characterDescSkillStaves.Default.(int)
 	// characterDescSkillKnives is the schema descriptor for skill_knives field.
-	characterDescSkillKnives := characterFields[24].Descriptor()
+	characterDescSkillKnives := characterFields[25].Descriptor()
 	// character.DefaultSkillKnives holds the default value on creation for the skill_knives field.
 	character.DefaultSkillKnives = characterDescSkillKnives.Default.(int)
 	// characterDescSkillMartial is the schema descriptor for skill_martial field.
-	characterDescSkillMartial := characterFields[25].Descriptor()
+	characterDescSkillMartial := characterFields[26].Descriptor()
 	// character.DefaultSkillMartial holds the default value on creation for the skill_martial field.
 	character.DefaultSkillMartial = characterDescSkillMartial.Default.(int)
 	// characterDescSkillBrawling is the schema descriptor for skill_brawling field.
-	characterDescSkillBrawling := characterFields[26].Descriptor()
+	characterDescSkillBrawling := characterFields[27].Descriptor()
 	// character.DefaultSkillBrawling holds the default value on creation for the skill_brawling field.
 	character.DefaultSkillBrawling = characterDescSkillBrawling.Default.(int)
 	// characterDescSkillTech is the schema descriptor for skill_tech field.
-	characterDescSkillTech := characterFields[27].Descriptor()
+	characterDescSkillTech := characterFields[28].Descriptor()
 	// character.DefaultSkillTech holds the default value on creation for the skill_tech field.
 	character.DefaultSkillTech = characterDescSkillTech.Default.(int)
 	// characterDescSkillLightArmor is the schema descriptor for skill_light_armor field.
-	characterDescSkillLightArmor := characterFields[28].Descriptor()
+	characterDescSkillLightArmor := characterFields[29].Descriptor()
 	// character.DefaultSkillLightArmor holds the default value on creation for the skill_light_armor field.
 	character.DefaultSkillLightArmor = characterDescSkillLightArmor.Default.(int)
 	// characterDescSkillClothArmor is the schema descriptor for skill_cloth_armor field.
-	characterDescSkillClothArmor := characterFields[29].Descriptor()
+	characterDescSkillClothArmor := characterFields[30].Descriptor()
 	// character.DefaultSkillClothArmor holds the default value on creation for the skill_cloth_armor field.
 	character.DefaultSkillClothArmor = characterDescSkillClothArmor.Default.(int)
 	// characterDescSkillHeavyArmor is the schema descriptor for skill_heavy_armor field.
-	characterDescSkillHeavyArmor := characterFields[30].Descriptor()
+	characterDescSkillHeavyArmor := characterFields[31].Descriptor()
 	// character.DefaultSkillHeavyArmor holds the default value on creation for the skill_heavy_armor field.
 	character.DefaultSkillHeavyArmor = characterDescSkillHeavyArmor.Default.(int)
+	characterskillFields := schema.CharacterSkill{}.Fields()
+	_ = characterskillFields
+	// characterskillDescLevel is the schema descriptor for level field.
+	characterskillDescLevel := characterskillFields[0].Descriptor()
+	// characterskill.DefaultLevel holds the default value on creation for the level field.
+	characterskill.DefaultLevel = characterskillDescLevel.Default.(int)
+	// characterskillDescExperience is the schema descriptor for experience field.
+	characterskillDescExperience := characterskillFields[1].Descriptor()
+	// characterskill.DefaultExperience holds the default value on creation for the experience field.
+	characterskill.DefaultExperience = characterskillDescExperience.Default.(int)
+	charactertalentFields := schema.CharacterTalent{}.Fields()
+	_ = charactertalentFields
+	// charactertalentDescSlot is the schema descriptor for slot field.
+	charactertalentDescSlot := charactertalentFields[0].Descriptor()
+	// charactertalent.DefaultSlot holds the default value on creation for the slot field.
+	charactertalent.DefaultSlot = charactertalentDescSlot.Default.(int)
 	equipmentFields := schema.Equipment{}.Fields()
 	_ = equipmentFields
 	// equipmentDescLevel is the schema descriptor for level field.

--- a/server/db/schema/character.go
+++ b/server/db/schema/character.go
@@ -39,6 +39,9 @@ func (Character) Fields() []ent.Field {
 			Default("human"),
 		field.String("class").
 			Default("adventurer"),
+		field.String("specialty").
+			Optional().
+			Comment("Class specialty (e.g., fighter for warrior)"),
 		field.Int("level").
 			Default(1),
 		field.Int("constitution").
@@ -88,5 +91,8 @@ func (Character) Edges() []ent.Edge {
 			Unique(),
 		edge.To("npcTemplate", NPCTemplate.Type).
 			Unique(),
+		edge.To("available_talents", AvailableTalent.Type),
+		edge.To("skills", CharacterSkill.Type),
+		edge.To("talents", CharacterTalent.Type),
 	}
 }

--- a/server/routes/character_routes.go
+++ b/server/routes/character_routes.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"herbst-server/constants"
 	"herbst-server/db"
 	"herbst-server/db/character"
 	"herbst-server/db/room"
@@ -351,8 +352,18 @@ func RegisterCharacterRoutes(router *gin.Engine, client *db.Client) {
 			class = req.Class
 		}
 
-		// Create the character
-		char, err := client.Character.
+		// Get class configuration with specialty
+		classConfig := constants.GetClassConfig(class, "")
+
+		// Calculate base stats with class bonuses
+		baseStrength := constants.DefaultStats.Strength + classConfig.StatBonuses.Strength
+		baseDexterity := constants.DefaultStats.Dexterity + classConfig.StatBonuses.Dexterity
+		baseConstitution := constants.DefaultStats.Constitution + classConfig.StatBonuses.Constitution
+		baseIntelligence := constants.DefaultStats.Intelligence + classConfig.StatBonuses.Intelligence
+		baseWisdom := constants.DefaultStats.Wisdom + classConfig.StatBonuses.Wisdom
+
+		// Create the character builder
+		builder := client.Character.
 			Create().
 			SetName(req.Name).
 			SetPassword(hashedPassword).
@@ -367,7 +378,33 @@ func RegisterCharacterRoutes(router *gin.Engine, client *db.Client) {
 			SetStartingRoomId(startingRoomID).
 			SetRace(race).
 			SetClass(class).
-			Save(c.Request.Context())
+			SetSpecialty(classConfig.Specialty).
+			SetStrength(baseStrength).
+			SetDexterity(baseDexterity).
+			SetConstitution(baseConstitution).
+			SetIntelligence(baseIntelligence).
+			SetWisdom(baseWisdom)
+
+		// Apply starting skills
+		for skill, level := range classConfig.StartingSkills {
+			switch skill {
+			case "blades":
+				builder.SetSkillBlades(level)
+			case "staves":
+				builder.SetSkillStaves(level)
+			case "knives":
+				builder.SetSkillKnives(level)
+			case "martial":
+				builder.SetSkillMartial(level)
+			case "brawling":
+				builder.SetSkillBrawling(level)
+			case "tech":
+				builder.SetSkillTech(level)
+			}
+		}
+
+		// Create the character
+		char, err := builder.Save(c.Request.Context())
 
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -389,6 +426,12 @@ func RegisterCharacterRoutes(router *gin.Engine, client *db.Client) {
 			"max_mana":        char.MaxMana,
 			"race":            char.Race,
 			"class":           char.Class,
+			"specialty":       char.Specialty,
+			"strength":        char.Strength,
+			"dexterity":       char.Dexterity,
+			"constitution":    char.Constitution,
+			"intelligence":    char.Intelligence,
+			"wisdom":          char.Wisdom,
 		})
 	})
 
@@ -459,6 +502,75 @@ func RegisterCharacterRoutes(router *gin.Engine, client *db.Client) {
 			"id":    char.ID,
 			"name":  char.Name,
 			"class": char.Class,
+		})
+	})
+
+	// Get character specialty
+	router.GET("/characters/:id/specialty", func(c *gin.Context) {
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid character ID"})
+			return
+		}
+
+		char, err := client.Character.Get(c.Request.Context(), id)
+		if err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Character not found"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"id":        char.ID,
+			"name":      char.Name,
+			"class":     char.Class,
+			"specialty": char.Specialty,
+		})
+	})
+
+	// Update character specialty
+	router.PUT("/characters/:id/specialty", func(c *gin.Context) {
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid character ID"})
+			return
+		}
+
+		var req struct {
+			Specialty string `json:"specialty" binding:"required"`
+		}
+
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		char, err := client.Character.UpdateOneID(id).SetSpecialty(req.Specialty).Save(c.Request.Context())
+		if err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Character not found"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"id":        char.ID,
+			"name":      char.Name,
+			"class":     char.Class,
+			"specialty": char.Specialty,
+		})
+	})
+
+	// Get available specialties for a class
+	router.GET("/classes/:class/specialties", func(c *gin.Context) {
+		class := c.Param("class")
+
+		specialties, ok := constants.ClassSpecialties[class]
+		if !ok {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Class not found"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"class":       class,
+			"specialties": specialties,
 		})
 	})
 


### PR DESCRIPTION
## Summary

Implements the Warrior class with Fighter specialty for Herbst MUD.

### Changes
- **Character schema**: Added `specialty` field to Character entity
- **Class constants**: Created `class_specialties.go` with:
  - `ClassSpecialties` map defining available specialties per class
  - `StartingConfigs` map with class starting skills, talents, and stat bonuses
  - `GetClassConfig()` and `GetSpecialty()` helper functions

### Warrior Fighter Configuration
- **Starting Skills**: `blades(1)`, `brawling(1)`
- **Starting Talents**: `slash`, `parry`, `smash`, `crash`
- **Stat Bonuses**: `STR+3`, `CON+1`
- **Description**: Defenders of survivor enclaves, battle-hardened veterans

### API Endpoints
- `GET /characters/:id/specialty` - Get character specialty
- `PUT /characters/:id/specialty` - Update character specialty
- `GET /classes/:class/specialties` - Get available specialties for a class

### Character Creation
When creating a character with `class: "warrior"`:
1. Automatically assigns `specialty: "fighter"` (first specialty)
2. Applies class stat bonuses to base stats
3. Sets starting skill levels

### Tests
All 15 tests pass in `constants` package.

## Related
- Closes #81
- Design doc: CLASS_SYSTEM_SPIKE.md
- ERD: data-model.md

## Review
Raphael for QA.