### PR TITLE
feat(combat): Combat Phase 2 - Actions, Damage, Interrupts, UI

### DIFF
--- a/herbst/combat/action_queue.go
+++ b/herbst/combat/action_queue.go
@@ -1,0 +1,166 @@
+package combat
+
+import (
+	"sort"
+	"sync"
+)
+
+// ActionPriority defines when an action executes in the tick
+type ActionPriority int
+
+const (
+	// PriorityImmediate executes first (instant reactions)
+	PriorityImmediate ActionPriority = iota
+	// PriorityFast executes early (quick actions like parry)
+	PriorityFast
+	// PriorityNormal executes in normal order (most actions)
+	PriorityNormal
+	// PrioritySlow executes late (heavy attacks, spells)
+	PrioritySlow
+	// PriorityLast executes last (delayed effects)
+	PriorityLast
+)
+
+// Action is an alias to ActionDefinition for queue compatibility
+// The full definition is in actions.go
+
+// QueuedAction represents an action queued for a specific tick
+type QueuedAction struct {
+	Action      *ActionDefinition `json:"action"`
+	Source      *Participant `json:"source"`
+	Target      *Participant `json:"target"`
+	TickNumber  int         `json:"tickNumber"`  // Which tick this executes on
+	Priority    ActionPriority `json:"priority"`
+	QueuedAt    int         `json:"queuedAt"`    // Tick when this was queued
+	ChannelTick int         `json:"channelTick"` // Current channel progress
+	ChargeTick   int         `json:"chargeTick"`  // Current charge progress
+}
+
+// ActionQueue manages pending combat actions
+type ActionQueue struct {
+	mu     sync.RWMutex
+	actions []*QueuedAction
+}
+
+// NewActionQueue creates a new action queue
+func NewActionQueue() *ActionQueue {
+	return &ActionQueue{
+		actions: make([]*QueuedAction, 0),
+	}
+}
+
+// Queue adds an action to the queue
+func (aq *ActionQueue) Queue(action *ActionDefinition, source, target *Participant, tickNumber int) *QueuedAction {
+	aq.mu.Lock()
+	defer aq.mu.Unlock()
+
+	qa := &QueuedAction{
+		Action:     action,
+		Source:     source,
+		Target:     target,
+		TickNumber: tickNumber,
+		Priority:   action.Priority,
+		QueuedAt:   tickNumber,
+	}
+
+	// For channel actions, set the current channel tick
+	if action.Type == ActionChannel {
+		qa.ChannelTick = 1
+	}
+	// For charge actions, set the current charge tick
+	if action.Type == ActionCharge {
+		qa.ChargeTick = 1
+	}
+
+	aq.actions = append(aq.actions, qa)
+	return qa
+}
+
+// QueueImmediate queues an action for immediate execution (current tick)
+func (aq *ActionQueue) QueueImmediate(action *ActionDefinition, source, target *Participant, currentTick int) *QueuedAction {
+	return aq.Queue(action, source, target, currentTick)
+}
+
+// QueueForNextTick queues an action for the next tick
+func (aq *ActionQueue) QueueForNextTick(action *ActionDefinition, source, target *Participant, currentTick int) *QueuedAction {
+	return aq.Queue(action, source, target, currentTick+1)
+}
+
+// GetActionsForTick returns all actions that should execute on a given tick, sorted by priority
+func (aq *ActionQueue) GetActionsForTick(tick int) []*QueuedAction {
+	aq.mu.RLock()
+	defer aq.mu.RUnlock()
+
+	var result []*QueuedAction
+	for _, qa := range aq.actions {
+		if qa.TickNumber == tick {
+			result = append(result, qa)
+		}
+	}
+
+	// Sort by priority (lower = earlier execution)
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Priority != result[j].Priority {
+			return result[i].Priority < result[j].Priority
+		}
+		// Same priority: higher initiative acts first
+		return result[i].Source.Initiative > result[j].Source.Initiative
+	})
+
+	return result
+}
+
+// Remove removes a queued action
+func (aq *ActionQueue) Remove(qa *QueuedAction) {
+	aq.mu.Lock()
+	defer aq.mu.Unlock()
+
+	for i, action := range aq.actions {
+		if action == qa {
+			aq.actions = append(aq.actions[:i], aq.actions[i+1:]...)
+			break
+		}
+	}
+}
+
+// RemoveByID removes a queued action by source ID
+func (aq *ActionQueue) RemoveByID(sourceID int) {
+	aq.mu.Lock()
+	defer aq.mu.Unlock()
+
+	newActions := make([]*QueuedAction, 0)
+	for _, qa := range aq.actions {
+		if qa.Source.ID != sourceID {
+			newActions = append(newActions, qa)
+		}
+	}
+	aq.actions = newActions
+}
+
+// Clear removes all actions from the queue
+func (aq *ActionQueue) Clear() {
+	aq.mu.Lock()
+	defer aq.mu.Unlock()
+	aq.actions = make([]*QueuedAction, 0)
+}
+
+// GetPendingActionsForParticipant returns all pending actions for a specific participant
+func (aq *ActionQueue) GetPendingActionsForParticipant(participantID int) []*QueuedAction {
+	aq.mu.RLock()
+	defer aq.mu.RUnlock()
+
+	var result []*QueuedAction
+	for _, qa := range aq.actions {
+		if qa.Source.ID == participantID {
+			result = append(result, qa)
+		}
+	}
+	return result
+}
+
+// Count returns the number of actions in the queue
+func (aq *ActionQueue) Count() int {
+	aq.mu.RLock()
+	defer aq.mu.RUnlock()
+	return len(aq.actions)
+}

--- a/herbst/combat/actions.go
+++ b/herbst/combat/actions.go
@@ -1,0 +1,504 @@
+package combat
+
+// ActionType defines how an action executes over time
+type ActionType string
+
+const (
+	// ActionInstant executes immediately in the current tick
+	// These actions have their full effect applied immediately
+	ActionInstant ActionType = "INSTANT"
+	
+	// ActionChannel requires the participant to remain active for multiple ticks
+	// Effect is applied each tick during the channel
+	ActionChannel ActionType = "CHANNEL"
+	
+	// ActionCharge requires buildup ticks before the effect executes
+	// Effect is applied only after all charge ticks complete
+	ActionCharge ActionType = "CHARGE"
+)
+
+// ActionCategory groups related actions for organization
+type ActionCategory string
+
+const (
+	CategoryBasic    ActionCategory = "BASIC"    // Basic actions (attack, defend, flee)
+	CategorySkill    ActionCategory = "SKILL"    // Skill actions (class-specific)
+	CategoryTalent   ActionCategory = "TALENT"   // Talent actions (learned abilities)
+	CategoryItem     ActionCategory = "ITEM"     // Item usage actions
+	CategoryReaction ActionCategory = "REACTION" // Reactive actions (parry, counter)
+)
+
+// ActionDefinition defines an action's properties and tick costs
+type ActionDefinition struct {
+	ID          string         `json:"id"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Category    ActionCategory `json:"category"`
+	Type        ActionType     `json:"type"`
+	
+	// Tick costs
+	TickCost     int `json:"tickCost"`     // Ticks until action executes (for Instant/Charge)
+	ChannelTicks int `json:"channelTicks"` // Total ticks for channeling (for Channel)
+	ChargeTicks  int `json:"chargeTicks"`  // Buildup ticks before execution (for Charge)
+	
+	// Resource costs
+	ManaCost    int `json:"manaCost"`
+	StaminaCost int `json:"staminaCost"`
+	
+	// Combat effect
+	BaseDamage int `json:"baseDamage"`
+	BaseHeal   int `json:"baseHeal"`
+	
+	// Action properties
+	Cooldown      int  `json:"cooldown"`      // Ticks before can use again
+	MaxTargets     int  `json:"maxTargets"`    // Maximum targets (1 for single, -1 for AoE)
+	Range          int  `json:"range"`         // 0 = melee, 1+ = ranged tiles
+	RequiresTarget bool `json:"requiresTarget"`
+	IsDefensive   bool `json:"isDefensive"`
+	IsOffensive   bool `json:"isOffensive"`
+	IsSupport     bool `json:"isSupport"`
+	
+	// Priority for execution order (lower = earlier)
+	Priority ActionPriority `json:"priority"`
+	
+	// Tags for special handling
+	Tags []string `json:"tags"`
+}
+
+// BasicActions defines the fundamental combat actions
+var BasicActions = map[string]*ActionDefinition{
+	"attack": {
+		ID:             "attack",
+		Name:           "Attack",
+		Description:    "A basic attack dealing damage based on your weapon.",
+		Category:       CategoryBasic,
+		Type:           ActionInstant,
+		TickCost:       1,
+		ManaCost:       0,
+		StaminaCost:    0,
+		BaseDamage:     10,
+		Cooldown:       0,
+		MaxTargets:     1,
+		Range:          0,
+		RequiresTarget: true,
+		IsDefensive:    false,
+		IsOffensive:    true,
+		IsSupport:      false,
+		Priority:       PriorityNormal,
+		Tags:           []string{"physical", "melee"},
+	},
+	"defend": {
+		ID:             "defend",
+		Name:           "Defend",
+		Description:    "Take a defensive stance, reducing incoming damage by 50% this tick.",
+		Category:       CategoryBasic,
+		Type:           ActionInstant,
+		TickCost:       1,
+		ManaCost:       0,
+		StaminaCost:    5,
+		BaseDamage:     0,
+		BaseHeal:       0,
+		Cooldown:       0,
+		MaxTargets:     0,
+		Range:          0,
+		RequiresTarget: false,
+		IsDefensive:    true,
+		IsOffensive:    false,
+		IsSupport:      false,
+		Priority:       PriorityFast,
+		Tags:           []string{"defensive", "stance"},
+	},
+	"flee": {
+		ID:             "flee",
+		Name:           "Flee",
+		Description:    "Attempt to escape from combat.",
+		Category:       CategoryBasic,
+		Type:           ActionInstant,
+		TickCost:       1,
+		ManaCost:       0,
+		StaminaCost:    10,
+		BaseDamage:     0,
+		Cooldown:       0,
+		MaxTargets:     0,
+		Range:          0,
+		RequiresTarget: false,
+		IsDefensive:    false,
+		IsOffensive:    false,
+		IsSupport:      false,
+		Priority:       PriorityLast,
+		Tags:           []string{"escape"},
+	},
+	"item": {
+		ID:             "item",
+		Name:           "Use Item",
+		Description:    "Use an item from your inventory.",
+		Category:       CategoryBasic,
+		Type:           ActionInstant,
+		TickCost:       1,
+		ManaCost:       0,
+		StaminaCost:    0,
+		BaseDamage:     0,
+		Cooldown:       0,
+		MaxTargets:     1,
+		Range:          0,
+		RequiresTarget: false,
+		IsDefensive:    false,
+		IsOffensive:    false,
+		IsSupport:      true,
+		Priority:       PriorityNormal,
+		Tags:           []string{"item", "inventory"},
+	},
+	"wait": {
+		ID:             "wait",
+		Name:           "Wait",
+		Description:    "Skip your turn and recover 10 stamina.",
+		Category:       CategoryBasic,
+		Type:           ActionInstant,
+		TickCost:       0,
+		ManaCost:       0,
+		StaminaCost:    0,
+		BaseDamage:     0,
+		BaseHeal:       0,
+		Cooldown:       0,
+		MaxTargets:     0,
+		Range:          0,
+		RequiresTarget: false,
+		IsDefensive:    false,
+		IsOffensive:    false,
+		IsSupport:      false,
+		Priority:       PriorityLast,
+		Tags:           []string{"skip"},
+	},
+}
+
+// SkillActions defines class-based combat skills
+var SkillActions = map[string]*ActionDefinition{
+	// Warrior skills
+	"slash": {
+		ID:             "slash",
+		Name:           "Slash",
+		Description:    "A quick slash attack dealing 1.5x weapon damage.",
+		Category:       CategorySkill,
+		Type:           ActionInstant,
+		TickCost:       1,
+		ManaCost:       0,
+		StaminaCost:    8,
+		BaseDamage:     15,
+		Cooldown:       2,
+		MaxTargets:     1,
+		Range:          0,
+		RequiresTarget: true,
+		IsDefensive:    false,
+		IsOffensive:    true,
+		IsSupport:      false,
+		Priority:       PriorityNormal,
+		Tags:           []string{"physical", "melee", "warrior"},
+	},
+	"heavy_strike": {
+		ID:             "heavy_strike",
+		Name:           "Heavy Strike",
+		Description:    "A powerful strike that takes an extra tick to wind up, dealing 2.5x damage.",
+		Category:       CategorySkill,
+		Type:           ActionCharge,
+		TickCost:       1,
+		ChargeTicks:    1,
+		ManaCost:       0,
+		StaminaCost:    15,
+		BaseDamage:     25,
+		Cooldown:       3,
+		MaxTargets:     1,
+		Range:          0,
+		RequiresTarget: true,
+		IsDefensive:    false,
+		IsOffensive:    true,
+		IsSupport:      false,
+		Priority:       PrioritySlow,
+		Tags:           []string{"physical", "melee", "warrior", "charge"},
+	},
+	"parry": {
+		ID:             "parry",
+		Name:           "Parry",
+		Description:    "Reactively block the next incoming attack and counter for half damage.",
+		Category:       CategorySkill,
+		Type:           ActionInstant,
+		TickCost:       0,
+		ManaCost:       0,
+		StaminaCost:    12,
+		BaseDamage:     5,
+		Cooldown:       4,
+		MaxTargets:     1,
+		Range:          0,
+		RequiresTarget: false,
+		IsDefensive:    true,
+		IsOffensive:    false,
+		IsSupport:      false,
+		Priority:       PriorityImmediate,
+		Tags:           []string{"defensive", "reaction", "warrior"},
+	},
+	"shield_bash": {
+		ID:             "shield_bash",
+		Name:           "Shield Bash",
+		Description:    "Strike with your shield, stunning the target for 1 tick.",
+		Category:       CategorySkill,
+		Type:           ActionInstant,
+		TickCost:       1,
+		ManaCost:       0,
+		StaminaCost:    10,
+		BaseDamage:     8,
+		Cooldown:       3,
+		MaxTargets:     1,
+		Range:          0,
+		RequiresTarget: true,
+		IsDefensive:    false,
+		IsOffensive:    true,
+		IsSupport:      false,
+		Priority:       PriorityFast,
+		Tags:           []string{"physical", "melee", "warrior", "stun"},
+	},
+	
+	// Mage skills
+	"fireball": {
+		ID:             "fireball",
+		Name:           "Fireball",
+		Description:    "Hurl a ball of fire at the enemy, dealing fire damage.",
+		Category:       CategorySkill,
+		Type:           ActionCharge,
+		TickCost:       1,
+		ChargeTicks:    2,
+		ManaCost:       20,
+		StaminaCost:    0,
+		BaseDamage:     35,
+		Cooldown:       4,
+		MaxTargets:     1,
+		Range:          3,
+		RequiresTarget: true,
+		IsDefensive:    false,
+		IsOffensive:    true,
+		IsSupport:      false,
+		Priority:       PrioritySlow,
+		Tags:           []string{"magic", "fire", "mage", "charge"},
+	},
+	"ice_shield": {
+		ID:             "ice_shield",
+		Name:           "Ice Shield",
+		Description:    "Create a protective barrier of ice that absorbs damage.",
+		Category:       CategorySkill,
+		Type:           ActionInstant,
+		TickCost:       1,
+		ManaCost:       15,
+		StaminaCost:    0,
+		BaseDamage:     0,
+		Cooldown:       5,
+		MaxTargets:     0,
+		Range:          0,
+		RequiresTarget: false,
+		IsDefensive:    true,
+		IsOffensive:    false,
+		IsSupport:      false,
+		Priority:       PriorityNormal,
+		Tags:           []string{"magic", "ice", "mage", "shield"},
+	},
+	"channel_mana": {
+		ID:             "channel_mana",
+		Name:           "Channel Mana",
+		Description:    "Focus to regenerate mana over 3 ticks.",
+		Category:       CategorySkill,
+		Type:           ActionChannel,
+		ChannelTicks:   3,
+		ManaCost:       0,
+		StaminaCost:    5,
+		BaseHeal:       10, // Per tick
+		Cooldown:       0,
+		MaxTargets:     0,
+		Range:          0,
+		RequiresTarget: false,
+		IsDefensive:    false,
+		IsOffensive:    false,
+		IsSupport:      true,
+		Priority:       PriorityNormal,
+		Tags:           []string{"magic", "mage", "channel", "regen"},
+	},
+	
+	// Rogue skills
+	"backstab": {
+		ID:             "backstab",
+		Name:           "Backstab",
+		Description:    "Strike from behind for 3x damage. Requires being behind the target.",
+		Category:       CategorySkill,
+		Type:           ActionInstant,
+		TickCost:       1,
+		ManaCost:       0,
+		StaminaCost:    12,
+		BaseDamage:     30,
+		Cooldown:       3,
+		MaxTargets:     1,
+		Range:          0,
+		RequiresTarget: true,
+		IsDefensive:    false,
+		IsOffensive:    true,
+		IsSupport:      false,
+		Priority:       PriorityFast,
+		Tags:           []string{"physical", "melee", "rogue", "stealth"},
+	},
+	"poison_blade": {
+		ID:             "poison_blade",
+		Name:           "Poison Blade",
+		Description:    "Coat your weapon in poison, applying DoT for 3 ticks.",
+		Category:       CategorySkill,
+		Type:           ActionInstant,
+		TickCost:       1,
+		ManaCost:       0,
+		StaminaCost:    8,
+		BaseDamage:     5,
+		Cooldown:       4,
+		MaxTargets:     1,
+		Range:          0,
+		RequiresTarget: true,
+		IsDefensive:    false,
+		IsOffensive:    true,
+		IsSupport:      false,
+		Priority:       PriorityNormal,
+		Tags:           []string{"physical", "melee", "rogue", "poison", "dot"},
+	},
+	"smoke_bomb": {
+		ID:             "smoke_bomb",
+		Name:           "Smoke Bomb",
+		Description:    "Create a smoke cloud, increasing dodge chance for 2 ticks.",
+		Category:       CategorySkill,
+		Type:           ActionInstant,
+		TickCost:       1,
+		ManaCost:       0,
+		StaminaCost:    10,
+		BaseDamage:     0,
+		Cooldown:       5,
+		MaxTargets:     0,
+		Range:          0,
+		RequiresTarget: false,
+		IsDefensive:    true,
+		IsOffensive:    false,
+		IsSupport:      false,
+		Priority:       PriorityFast,
+		Tags:           []string{"defensive", "rogue", "evasion"},
+	},
+	
+	// Cleric skills
+	"heal": {
+		ID:             "heal",
+		Name:           "Heal",
+		Description:    "Restore health to a target ally.",
+		Category:       CategorySkill,
+		Type:           ActionInstant,
+		TickCost:       1,
+		ManaCost:       15,
+		StaminaCost:    0,
+		BaseDamage:     0,
+		BaseHeal:       20,
+		Cooldown:       2,
+		MaxTargets:     1,
+		Range:          2,
+		RequiresTarget: true,
+		IsDefensive:    false,
+		IsOffensive:    false,
+		IsSupport:      true,
+		Priority:       PriorityNormal,
+		Tags:           []string{"magic", "holy", "cleric", "healing"},
+	},
+	"greater_heal": {
+		ID:             "greater_heal",
+		Name:           "Greater Heal",
+		Description:    "Channel powerful healing over 2 ticks.",
+		Category:       CategorySkill,
+		Type:           ActionChannel,
+		ChannelTicks:   2,
+		ManaCost:       25,
+		StaminaCost:    0,
+		BaseDamage:     0,
+		BaseHeal:       15, // Per tick
+		Cooldown:       4,
+		MaxTargets:     1,
+		Range:          2,
+		RequiresTarget: true,
+		IsDefensive:    false,
+		IsOffensive:    false,
+		IsSupport:      true,
+		Priority:       PriorityNormal,
+		Tags:           []string{"magic", "holy", "cleric", "healing", "channel"},
+	},
+	"shield_of_faith": {
+		ID:             "shield_of_faith",
+		Name:           "Shield of Faith",
+		Description:    "Grant a protective shield for 3 ticks.",
+		Category:       CategorySkill,
+		Type:           ActionInstant,
+		TickCost:       1,
+		ManaCost:       20,
+		StaminaCost:    0,
+		BaseDamage:     0,
+		Cooldown:       6,
+		MaxTargets:     1,
+		Range:          2,
+		RequiresTarget: true,
+		IsDefensive:    true,
+		IsOffensive:    false,
+		IsSupport:      true,
+		Priority:       PriorityNormal,
+		Tags:           []string{"magic", "holy", "cleric", "shield"},
+	},
+}
+
+// GetActionDefinition retrieves an action definition by ID
+func GetActionDefinition(id string) (*ActionDefinition, bool) {
+	// Check basic actions first
+	if action, exists := BasicActions[id]; exists {
+		return action, true
+	}
+	// Check skill actions
+	if action, exists := SkillActions[id]; exists {
+		return action, true
+	}
+	return nil, false
+}
+
+// GetAllActionDefinitions returns all action definitions
+func GetAllActionDefinitions() map[string]*ActionDefinition {
+	result := make(map[string]*ActionDefinition)
+	for k, v := range BasicActions {
+		result[k] = v
+	}
+	for k, v := range SkillActions {
+		result[k] = v
+	}
+	return result
+}
+
+// GetActionsByCategory returns all actions of a specific category
+func GetActionsByCategory(category ActionCategory) []*ActionDefinition {
+	var result []*ActionDefinition
+	for _, action := range BasicActions {
+		if action.Category == category {
+			result = append(result, action)
+		}
+	}
+	for _, action := range SkillActions {
+		if action.Category == category {
+			result = append(result, action)
+		}
+	}
+	return result
+}
+
+// GetActionsByType returns all actions of a specific type
+func GetActionsByType(actionType ActionType) []*ActionDefinition {
+	var result []*ActionDefinition
+	for _, action := range BasicActions {
+		if action.Type == actionType {
+			result = append(result, action)
+		}
+	}
+	for _, action := range SkillActions {
+		if action.Type == actionType {
+			result = append(result, action)
+		}
+	}
+	return result
+}

--- a/herbst/combat/actions_test.go
+++ b/herbst/combat/actions_test.go
@@ -1,0 +1,142 @@
+package combat
+
+import (
+	"testing"
+)
+
+func TestGetActionDefinition_BasicActions(t *testing.T) {
+	// Test all basic actions exist
+	basicActions := []string{"attack", "defend", "flee", "item", "wait"}
+	
+	for _, actionID := range basicActions {
+		action, exists := GetActionDefinition(actionID)
+		if !exists {
+			t.Errorf("Basic action '%s' should exist", actionID)
+			continue
+		}
+		
+		if action.Category != CategoryBasic {
+			t.Errorf("Action '%s' should be CategoryBasic, got %v", actionID, action.Category)
+		}
+	}
+}
+
+func TestGetActionDefinition_SkillActions(t *testing.T) {
+	// Test some skill actions exist
+	skillActions := []string{"slash", "heavy_strike", "parry", "fireball", "heal", "backstab"}
+	
+	for _, actionID := range skillActions {
+		action, exists := GetActionDefinition(actionID)
+		if !exists {
+			t.Errorf("Skill action '%s' should exist", actionID)
+			continue
+		}
+		
+		if action.Category != CategorySkill {
+			t.Errorf("Action '%s' should be CategorySkill, got %v", actionID, action.Category)
+		}
+	}
+}
+
+func TestGetActionDefinition_NonExistent(t *testing.T) {
+	_, exists := GetActionDefinition("nonexistent_action")
+	if exists {
+		t.Error("Non-existent action should not return true")
+	}
+}
+
+func TestActionDefinition_TickCosts(t *testing.T) {
+	tests := []struct {
+		actionID  string
+		tickCost  int
+		actionType ActionType
+	}{
+		{"attack", 1, ActionInstant},
+		{"defend", 1, ActionInstant},
+		{"wait", 0, ActionInstant},
+		{"heavy_strike", 1, ActionCharge}, // Has charge ticks
+		{"fireball", 1, ActionCharge},
+		{"channel_mana", 0, ActionChannel}, // Channel type
+	}
+	
+	for _, tt := range tests {
+		action, exists := GetActionDefinition(tt.actionID)
+		if !exists {
+			t.Errorf("Action '%s' should exist", tt.actionID)
+			continue
+		}
+		
+		if action.TickCost != tt.tickCost {
+			t.Errorf("Action '%s' should have tick cost %d, got %d", 
+				tt.actionID, tt.tickCost, action.TickCost)
+		}
+		
+		if action.Type != tt.actionType {
+			t.Errorf("Action '%s' should have type %s, got %s",
+				tt.actionID, tt.actionType, action.Type)
+		}
+	}
+}
+
+func TestActionDefinition_ResourceCosts(t *testing.T) {
+	// Attack should be free
+	attack, _ := GetActionDefinition("attack")
+	if attack.ManaCost != 0 || attack.StaminaCost != 0 {
+		t.Errorf("Attack should be free, got mana=%d stamina=%d", 
+			attack.ManaCost, attack.StaminaCost)
+	}
+	
+	// Defend should cost stamina
+	defend, _ := GetActionDefinition("defend")
+	if defend.StaminaCost != 5 {
+		t.Errorf("Defend should cost 5 stamina, got %d", defend.StaminaCost)
+	}
+	
+	// Fireball should cost mana
+	fireball, _ := GetActionDefinition("fireball")
+	if fireball.ManaCost != 20 {
+		t.Errorf("Fireball should cost 20 mana, got %d", fireball.ManaCost)
+	}
+}
+
+func TestGetActionsByCategory(t *testing.T) {
+	basicActions := GetActionsByCategory(CategoryBasic)
+	if len(basicActions) != 5 {
+		t.Errorf("Expected 5 basic actions, got %d", len(basicActions))
+	}
+	
+	skillActions := GetActionsByCategory(CategorySkill)
+	if len(skillActions) < 12 {
+		t.Errorf("Expected at least 12 skill actions, got %d", len(skillActions))
+	}
+}
+
+func TestGetActionsByType(t *testing.T) {
+	instantActions := GetActionsByType(ActionInstant)
+	if len(instantActions) == 0 {
+		t.Error("Should have instant actions")
+	}
+	
+	chargeActions := GetActionsByType(ActionCharge)
+	if len(chargeActions) == 0 {
+		t.Error("Should have charge actions")
+	}
+	
+	channelActions := GetActionsByType(ActionChannel)
+	if len(channelActions) == 0 {
+		t.Error("Should have channel actions")
+	}
+}
+
+func TestGetAllActionDefinitions(t *testing.T) {
+	all := GetAllActionDefinitions()
+	
+	// Should include both basic and skill actions
+	if _, exists := all["attack"]; !exists {
+		t.Error("Should include basic 'attack'")
+	}
+	
+	if _, exists := all["fireball"]; !exists {
+		t.Error("Should include skill 'fireball'")
+	}
+}

--- a/herbst/combat/combat.go
+++ b/herbst/combat/combat.go
@@ -1,0 +1,195 @@
+package combat
+
+import (
+	"fmt"
+	"time"
+)
+
+// Combat represents a single combat encounter
+type Combat struct {
+	ID           CombatID
+	RoomID       int
+	Participants []*Participant
+	State        CombatState
+	TickNumber   int
+	TickCountdown float64 // Seconds until next tick (for UI display)
+	StartedAt    time.Time
+	EndedAt      time.Time
+
+	// Action queue for pending actions
+	ActionQueue *ActionQueue
+
+	// Effect registry for ongoing effects (DoT, HoT, buffs, debuffs)
+	Effects *EffectRegistry
+
+	// Tick channel for receiving tick events
+	tickChan <-chan Tick
+
+	// Combat log entries
+	Log []CombatLogEntry
+
+	// Weapon drops by player ID (populated on victory)
+	WeaponDrops map[int][]*WeaponDrop `json:"weaponDrops,omitempty"`
+}
+
+// CombatLogEntry represents a single entry in the combat log
+type CombatLogEntry struct {
+	Tick      int       `json:"tick"`
+	Timestamp time.Time `json:"timestamp"`
+	Message   string    `json:"message"`
+	Type      string    `json:"type"` // "damage", "heal", "effect", "system", "miss", "info"
+	SourceID  int       `json:"sourceId,omitempty"`
+	TargetID  int       `json:"targetId,omitempty"`
+	Value     int       `json:"value,omitempty"`
+}
+
+// WeaponDrop represents a weapon that can be dropped
+type WeaponDrop struct {
+	Name             string `json:"name"`
+	WeaponType       string `json:"weaponType"` // "sword", "pipe", "dagger", etc.
+	ClassRestriction string `json:"classRestriction"` // "warrior", "chef", etc. - empty means any
+	MinDamage        int    `json:"minDamage"`
+	MaxDamage        int    `json:"maxDamage"`
+	Guaranteed       bool   `json:"guaranteed"` // Guaranteed first drop
+}
+
+// Participant represents a character in combat
+type Participant struct {
+	ID           int       `json:"id"`
+	Name         string    `json:"name"`
+	IsPlayer     bool      `json:"isPlayer"`
+	IsNPC        bool      `json:"isNPC"`
+	UserID       int       `json:"userId,omitempty"` // For players
+	NPCID        int       `json:"npcId,omitempty"`  // For NPCs
+
+	// Weapon drop fields
+	HasGuaranteedDrop bool   `json:"hasGuaranteedDrop"` // NPC has guaranteed weapon drop
+	DropWeapon        string `json:"dropWeapon"`        // Name of weapon to drop
+
+	// Stats
+	HP           int       `json:"hp"`
+	MaxHP        int       `json:"maxHP"`
+	Mana         int       `json:"mana"`
+	MaxMana      int       `json:"maxMana"`
+	Stamina      int       `json:"stamina"`
+	MaxStamina   int       `json:"maxStamina"`
+	Level        int       `json:"level"`
+	Class        string    `json:"class,omitempty"`
+
+	// Combat stats
+	Attack       int       `json:"attack"`
+	Defense      int       `json:"defense"`
+	Dexterity    int       `json:"dexterity"` // For initiative
+	Initiative   int       `json:"initiative"` // Calculated at combat start
+
+	// Status
+	IsAlive      bool      `json:"isAlive"`
+	IsActive     bool      `json:"isActive"` // In current turn order
+	Team         int       `json:"team"` // 0 = player team, 1 = enemy team
+
+	// Position in turn order (set during initiative roll)
+	TurnPosition int       `json:"turnPosition"`
+
+	// Current action being prepared (for UI display)
+	CurrentAction *QueuedAction `json:"currentAction,omitempty"`
+
+	// Active effects on this participant
+	ActiveEffects []ActiveEffect `json:"activeEffects"`
+}
+
+// GetTeam returns the team number for this participant
+func (p *Participant) GetTeam() int {
+	return p.Team
+}
+
+// IsEnemy returns true if this participant is an enemy of the other
+func (p *Participant) IsEnemy(other *Participant) bool {
+	return p.Team != other.Team
+}
+
+// TakeDamage applies damage to the participant
+func (p *Participant) TakeDamage(damage int) int {
+	if damage < 0 {
+		damage = 0
+	}
+	p.HP -= damage
+	if p.HP < 0 {
+		p.HP = 0
+	}
+	if p.HP == 0 {
+		p.IsAlive = false
+	}
+	return damage
+}
+
+// Heal restores HP to the participant
+func (p *Participant) Heal(amount int) int {
+	if amount < 0 {
+		amount = 0
+	}
+	oldHP := p.HP
+	p.HP += amount
+	if p.HP > p.MaxHP {
+		p.HP = p.MaxHP
+	}
+	return p.HP - oldHP
+}
+
+// CanAct returns true if the participant can take actions
+func (p *Participant) CanAct() bool {
+	return p.IsAlive && p.HP > 0
+}
+
+// AddLogEntry adds an entry to the combat log
+func (c *Combat) AddLogEntry(entry CombatLogEntry) {
+	c.Log = append(c.Log, entry)
+}
+
+// FormatCombatLog is a helper for consistent log formatting
+func FormatCombatLog(format string, args ...interface{}) string {
+	return fmt.Sprintf(format, args...)
+}
+
+// GetParticipantByID finds a participant by their ID
+func (c *Combat) GetParticipantByID(id int) *Participant {
+	for _, p := range c.Participants {
+		if p.ID == id {
+			return p
+		}
+	}
+	return nil
+}
+
+// GetAliveParticipants returns all alive participants
+func (c *Combat) GetAliveParticipants() []*Participant {
+	alive := make([]*Participant, 0)
+	for _, p := range c.Participants {
+		if p.IsAlive {
+			alive = append(alive, p)
+		}
+	}
+	return alive
+}
+
+// GetAliveByTeam returns alive participants on a specific team
+func (c *Combat) GetAliveByTeam(team int) []*Participant {
+	alive := make([]*Participant, 0)
+	for _, p := range c.Participants {
+		if p.IsAlive && p.Team == team {
+			alive = append(alive, p)
+		}
+	}
+	return alive
+}
+
+// AllEnemiesDefeated returns true if all enemies are defeated
+func (c *Combat) AllEnemiesDefeated() bool {
+	enemies := c.GetAliveByTeam(1)
+	return len(enemies) == 0
+}
+
+// AllPlayersDefeated returns true if all players are defeated
+func (c *Combat) AllPlayersDefeated() bool {
+	players := c.GetAliveByTeam(0)
+	return len(players) == 0
+}

--- a/herbst/combat/damage.go
+++ b/herbst/combat/damage.go
@@ -1,0 +1,235 @@
+package combat
+
+import (
+	"math"
+)
+
+// DamageConfig holds configuration for damage calculation
+type DamageConfig struct {
+	// Minimum damage (floor)
+	MinDamage int
+	// Maximum damage before reduction
+	MaxDamage int
+}
+
+// DefaultDamageConfig is the default damage configuration
+var DefaultDamageConfig = DamageConfig{
+	MinDamage: 1,
+	MaxDamage: 999,
+}
+
+// SkillBonusTable defines skill level to damage bonus mapping
+// Level 0-25: 0%, 26-50: 10%, 51-75: 25%, 76-90: 50%, 91-99: 75%, 100: 100%
+var SkillBonusTable = []struct {
+	MinLevel int
+	MaxLevel int
+	Bonus    float64
+}{
+	{0, 25, 0.0},
+	{26, 50, 0.10},
+	{51, 75, 0.25},
+	{76, 90, 0.50},
+	{91, 99, 0.75},
+	{100, 100, 1.0},
+}
+
+// GetSkillBonus returns the damage bonus percentage for a skill level
+func GetSkillBonus(level int) float64 {
+	for _, tier := range SkillBonusTable {
+		if level >= tier.MinLevel && level <= tier.MaxLevel {
+			return tier.Bonus
+		}
+	}
+	// Level > 100 gets max bonus
+	if level > 100 {
+		return 1.0
+	}
+	return 0.0
+}
+
+// SkillLevelProvider is a function type for getting skill levels
+// This allows different implementations (from DB, from memory, etc.)
+type SkillLevelProvider func(participantID int, skillName string) int
+
+// DamageResult represents the result of a damage calculation
+type DamageResult struct {
+	BaseDamage      int     `json:"baseDamage"`
+	SkillBonus      float64 `json:"skillBonus"`
+	BuffBonus       float64 `json:"buffBonus"`
+	RawDamage       float64 `json:"rawDamage"`
+	Defense         int     `json:"defense"`
+	ArmorPercent    float64 `json:"armorPercent"`
+	FinalDamage     int     `json:"finalDamage"`
+	WasBlocked      bool    `json:"wasBlocked"`
+	WasCritical     bool    `json:"wasCritical"`
+	DamageAbsorbed  int     `json:"damageAbsorbed"`
+	ShieldRemaining int     `json:"shieldRemaining"`
+}
+
+// CalculateDamage calculates damage using the formula:
+// Damage = Base × (1 + SkillBonus) × (1 + BuffBonus) - Defense × (1 - Armor)
+// Minimum 1 damage
+func CalculateDamage(attacker, defender *Participant, action *ActionDefinition, registry *EffectRegistry) *DamageResult {
+	result := &DamageResult{}
+
+	// Base damage from action
+	result.BaseDamage = action.BaseDamage
+	if result.BaseDamage <= 0 {
+		result.BaseDamage = 10 // Default for basic attacks
+	}
+
+	// Skill bonus (would need skill level from participant)
+	// For now, assume skill level is stored in attacker's stats
+	// In real implementation, this would use SkillLevelProvider
+	skillLevel := attacker.Attack // Use attack stat as proxy for skill level
+	result.SkillBonus = GetSkillBonus(skillLevel)
+
+	// Buff bonus from strength buff
+	result.BuffBonus = GetDamageModifier(registry, attacker.ID)
+
+	// Calculate raw damage
+	result.RawDamage = float64(result.BaseDamage) * (1.0 + result.SkillBonus) * (1.0 + result.BuffBonus)
+
+	// Defense reduction
+	result.Defense = defender.Defense
+	result.ArmorPercent = 0.0 // TODO: Get armor from equipment
+
+	// Shield absorbs damage first
+	shield := registry.HasShield(defender.ID)
+	if shield > 0 {
+		if shield >= int(result.RawDamage) {
+			result.DamageAbsorbed = int(result.RawDamage)
+			result.ShieldRemaining = shield - int(result.RawDamage)
+			result.FinalDamage = 0
+			result.WasBlocked = true
+			return result
+		}
+		// Shield partially absorbs
+		result.DamageAbsorbed = shield
+		result.RawDamage -= float64(shield)
+	}
+
+	// Defense reduction (after shield)
+	defenseReduction := float64(result.Defense) * (1.0 - result.ArmorPercent)
+	damageAfterDefense := result.RawDamage - defenseReduction
+
+	// Incoming damage modifier (from buffs/debuffs)
+	incomingMod := GetIncomingDamageModifier(registry, defender.ID)
+	damageAfterDefense *= (1.0 + incomingMod)
+
+	// Floor to minimum
+	result.FinalDamage = int(math.Max(1.0, math.Floor(damageAfterDefense)))
+
+	// Cap at max
+	if result.FinalDamage > DefaultDamageConfig.MaxDamage {
+		result.FinalDamage = DefaultDamageConfig.MaxDamage
+	}
+
+	return result
+}
+
+// ApplyDamage applies damage to a participant and returns the actual damage dealt
+func ApplyDamage(attacker, defender *Participant, action *ActionDefinition, registry *EffectRegistry) int {
+	result := CalculateDamage(attacker, defender, action, registry)
+	damage := result.FinalDamage
+
+	// If shield absorbed all, no damage
+	if result.WasBlocked && damage == 0 {
+		return 0
+	}
+
+	// Apply damage to defender
+	defender.TakeDamage(damage)
+
+	// Update shield if it absorbed damage
+	if result.DamageAbsorbed > 0 && registry != nil {
+		// Shield damage is handled by the effect system
+		// The shield effect should have its value decremented
+		// For now, this is a simplified implementation
+	}
+
+	return damage
+}
+
+// CalculateHeal calculates healing amount
+func CalculateHeal(healer *Participant, action *ActionDefinition) int {
+	baseHeal := action.BaseHeal
+	if baseHeal <= 0 {
+		return 0
+	}
+
+	// TODO: Add skill bonus for healing
+	// For now, just return base heal
+	return baseHeal
+}
+
+// ApplyHeal applies healing to a participant and returns actual healing
+func ApplyHeal(healer, target *Participant, action *ActionDefinition) int {
+	healAmount := CalculateHeal(healer, action)
+	actualHeal := target.Heal(healAmount)
+	return actualHeal
+}
+
+// IsHit determines if an attack hits based on accuracy
+func IsHit(attacker, defender *Participant, registry *EffectRegistry) bool {
+	// Base hit chance
+	hitChance := 0.95 // 95% base hit chance
+
+	// Apply accuracy modifier from debuffs
+	accuracyMod := GetAccuracyModifier(registry, attacker.ID)
+	hitChance += accuracyMod
+
+	// Clamp to valid range
+	if hitChance < 0.0 {
+		hitChance = 0.0
+	}
+	if hitChance > 1.0 {
+		hitChance = 1.0
+	}
+
+	// Roll for hit
+	roll := float64(attacker.Dexterity%100) / 100.0 // Simplified random
+	return roll < hitChance
+}
+
+// DamageModifiers returns all active damage modifiers for a participant
+func DamageModifiers(participantID int, registry *EffectRegistry) (damageBonus, defenseBonus, accuracyMod float64) {
+	damageBonus = GetDamageModifier(registry, participantID)
+	defenseBonus = 0.0 // TODO: Get defense modifier from effects
+	accuracyMod = GetAccuracyModifier(registry, participantID)
+	return
+}
+
+// GetArmorPercent calculates armor percentage from equipment
+// TODO: Implement when equipment system is ready
+func GetArmorPercent(participant *Participant) float64 {
+	// Placeholder - would calculate from equipped items
+	return 0.0
+}
+
+// CalculateEffectiveHP calculates HP considering buffs/debuffs
+func CalculateEffectiveHP(participant *Participant, registry *EffectRegistry) int {
+	baseHP := participant.MaxHP
+
+	// TODO: Add HP buffs/debuffs
+	// For now, just return base
+	return baseHP
+}
+
+// CalculateEffectiveDefense calculates defense considering buffs/debuffs
+func CalculateEffectiveDefense(participant *Participant, registry *EffectRegistry) int {
+	baseDefense := participant.Defense
+
+	// Add defense from buffs
+	defenseMod := registry.GetStatModifier(participant.ID, StatDefense)
+	return baseDefense + defenseMod
+}
+
+// CalculateEffectiveAttack calculates attack considering buffs/debuffs
+func CalculateEffectiveAttack(participant *Participant, registry *EffectRegistry) int {
+	baseAttack := participant.Attack
+
+	// Add attack from buffs
+	attackMod := registry.GetStatModifier(participant.ID, StatAttack)
+	return baseAttack + attackMod
+}

--- a/herbst/combat/damage_test.go
+++ b/herbst/combat/damage_test.go
@@ -1,0 +1,354 @@
+package combat
+
+import (
+	"testing"
+)
+
+func TestGetSkillBonus(t *testing.T) {
+	tests := []struct {
+		level    int
+		expected float64
+	}{
+		{0, 0.0},
+		{25, 0.0},
+		{26, 0.10},
+		{50, 0.10},
+		{51, 0.25},
+		{75, 0.25},
+		{76, 0.50},
+		{90, 0.50},
+		{91, 0.75},
+		{99, 0.75},
+		{100, 1.0},
+		{150, 1.0}, // Over 100 gets max
+	}
+
+	for _, tt := range tests {
+		result := GetSkillBonus(tt.level)
+		if result != tt.expected {
+			t.Errorf("GetSkillBonus(%d) = %.2f, expected %.2f", tt.level, result, tt.expected)
+		}
+	}
+}
+
+func TestCalculateDamage_Basic(t *testing.T) {
+	registry := NewEffectRegistry()
+	action := &ActionDefinition{
+		ID:         "test_attack",
+		Name:       "Test Attack",
+		BaseDamage: 10,
+	}
+
+	attacker := &Participant{ID: 1, Name: "Attacker", HP: 100, MaxHP: 100, Attack: 20}
+	defender := &Participant{ID: 2, Name: "Defender", HP: 100, MaxHP: 100, Defense: 0}
+
+	result := CalculateDamage(attacker, defender, action, registry)
+
+	// Base 10 * (1 + 0) * (1 + 0) - 0 * (1 - 0) = 10
+	// Minimum 1
+	if result.BaseDamage != 10 {
+		t.Errorf("Expected base damage 10, got %d", result.BaseDamage)
+	}
+	if result.FinalDamage < 1 {
+		t.Errorf("Expected minimum 1 damage, got %d", result.FinalDamage)
+	}
+}
+
+func TestCalculateDamage_WithSkillBonus(t *testing.T) {
+	registry := NewEffectRegistry()
+	action := &ActionDefinition{
+		ID:         "test_attack",
+		Name:       "Test Attack",
+		BaseDamage: 10,
+	}
+
+	// Attack 50 gives 10% bonus
+	attacker := &Participant{ID: 1, Name: "Attacker", HP: 100, MaxHP: 100, Attack: 50}
+	defender := &Participant{ID: 2, Name: "Defender", HP: 100, MaxHP: 100, Defense: 0}
+
+	result := CalculateDamage(attacker, defender, action, registry)
+
+	// Base 10 * (1 + 0.10) * (1 + 0) = 11
+	if result.SkillBonus != 0.10 {
+		t.Errorf("Expected skill bonus 0.10, got %.2f", result.SkillBonus)
+	}
+	// Damage should be higher than base
+	if result.FinalDamage <= 10 {
+		t.Errorf("Expected damage > 10 with skill bonus, got %d", result.FinalDamage)
+	}
+}
+
+func TestCalculateDamage_WithDefense(t *testing.T) {
+	registry := NewEffectRegistry()
+	action := &ActionDefinition{
+		ID:         "test_attack",
+		Name:       "Test Attack",
+		BaseDamage: 20,
+	}
+
+	attacker := &Participant{ID: 1, Name: "Attacker", HP: 100, MaxHP: 100, Attack: 25}
+	defender := &Participant{ID: 2, Name: "Defender", HP: 100, MaxHP: 100, Defense: 5}
+
+	result := CalculateDamage(attacker, defender, action, registry)
+
+	// Base 20 * (1 + 0) - 5 = 15
+	if result.Defense != 5 {
+		t.Errorf("Expected defense 5, got %d", result.Defense)
+	}
+	if result.FinalDamage >= 20 {
+		t.Errorf("Expected damage < 20 with defense, got %d", result.FinalDamage)
+	}
+}
+
+func TestCalculateDamage_WithBuff(t *testing.T) {
+	registry := NewEffectRegistry()
+	action := &ActionDefinition{
+		ID:         "test_attack",
+		Name:       "Test Attack",
+		BaseDamage: 10,
+	}
+
+	attacker := &Participant{ID: 1, Name: "Attacker", HP: 100, MaxHP: 100, Attack: 25}
+	defender := &Participant{ID: 2, Name: "Defender", HP: 100, MaxHP: 100, Defense: 0}
+
+	// Apply strength buff (+25% damage)
+	ApplyStatusEffect(registry, StatusBuffStrength, attacker.ID, attacker.ID)
+
+	result := CalculateDamage(attacker, defender, action, registry)
+
+	// Buff bonus should be 0.25
+	if result.BuffBonus != 0.25 {
+		t.Errorf("Expected buff bonus 0.25, got %.2f", result.BuffBonus)
+	}
+	// Base 10 * (1 + 0) * (1 + 0.25) = 12.5 → floor = 12
+	if result.FinalDamage < 10 {
+		t.Errorf("Expected damage >= 10 with buff, got %d", result.FinalDamage)
+	}
+}
+
+func TestCalculateDamage_Minimum(t *testing.T) {
+	registry := NewEffectRegistry()
+	action := &ActionDefinition{
+		ID:         "weak_attack",
+		Name:       "Weak Attack",
+		BaseDamage: 5,
+	}
+
+	attacker := &Participant{ID: 1, Name: "Attacker", HP: 100, MaxHP: 100, Attack: 0}
+	defender := &Participant{ID: 2, Name: "Defender", HP: 100, MaxHP: 100, Defense: 100} // High defense
+
+	result := CalculateDamage(attacker, defender, action, registry)
+
+	// Even with high defense, minimum should be 1
+	if result.FinalDamage < 1 {
+		t.Errorf("Expected minimum 1 damage, got %d", result.FinalDamage)
+	}
+}
+
+func TestApplyDamage(t *testing.T) {
+	registry := NewEffectRegistry()
+	action := &ActionDefinition{
+		ID:         "test_attack",
+		Name:       "Test Attack",
+		BaseDamage: 15,
+	}
+
+	attacker := &Participant{ID: 1, Name: "Attacker", HP: 100, MaxHP: 100, Attack: 25}
+	defender := &Participant{ID: 2, Name: "Defender", HP: 100, MaxHP: 100, Defense: 0}
+
+	damage := ApplyDamage(attacker, defender, action, registry)
+
+	if damage < 1 {
+		t.Errorf("Expected at least 1 damage, got %d", damage)
+	}
+	if defender.HP != 100-damage {
+		t.Errorf("Expected defender HP %d, got %d", 100-damage, defender.HP)
+	}
+}
+
+func TestApplyDamage_WithShield(t *testing.T) {
+	registry := NewEffectRegistry()
+	action := &ActionDefinition{
+		ID:         "test_attack",
+		Name:       "Test Attack",
+		BaseDamage: 10,
+	}
+
+	attacker := &Participant{ID: 1, Name: "Attacker", HP: 100, MaxHP: 100, Attack: 25}
+	defender := &Participant{ID: 2, Name: "Defender", HP: 100, MaxHP: 100, Defense: 0}
+
+	// Apply shield that absorbs damage
+	ApplyStatusEffect(registry, StatusBuffShield, defender.ID, defender.ID)
+
+	damage := ApplyDamage(attacker, defender, action, registry)
+
+	// With shield, damage should be reduced
+	// Note: This test depends on shield implementation
+	_ = damage // Damage might be 0 if shield absorbs all
+}
+
+func TestCalculateHeal(t *testing.T) {
+	action := &ActionDefinition{
+		ID:       "heal",
+		Name:     "Heal",
+		BaseHeal: 20,
+	}
+
+	healer := &Participant{ID: 1, Name: "Healer", HP: 100, MaxHP: 100}
+
+	healAmount := CalculateHeal(healer, action)
+	if healAmount != 20 {
+		t.Errorf("Expected heal 20, got %d", healAmount)
+	}
+}
+
+func TestApplyHeal(t *testing.T) {
+	action := &ActionDefinition{
+		ID:       "heal",
+		Name:     "Heal",
+		BaseHeal: 15,
+	}
+
+	healer := &Participant{ID: 1, Name: "Healer", HP: 100, MaxHP: 100}
+	target := &Participant{ID: 2, Name: "Target", HP: 50, MaxHP: 100}
+
+	actualHeal := ApplyHeal(healer, target, action)
+
+	if actualHeal != 15 {
+		t.Errorf("Expected heal 15, got %d", actualHeal)
+	}
+	if target.HP != 65 {
+		t.Errorf("Expected target HP 65, got %d", target.HP)
+	}
+}
+
+func TestApplyHeal_CappedAtMax(t *testing.T) {
+	action := &ActionDefinition{
+		ID:       "heal",
+		Name:     "Heal",
+		BaseHeal: 30,
+	}
+
+	healer := &Participant{ID: 1, Name: "Healer", HP: 100, MaxHP: 100}
+	target := &Participant{ID: 2, Name: "Target", HP: 90, MaxHP: 100}
+
+	actualHeal := ApplyHeal(healer, target, action)
+
+	// Can only heal 10 HP (to reach max)
+	if actualHeal != 10 {
+		t.Errorf("Expected heal 10 (capped), got %d", actualHeal)
+	}
+	if target.HP != 100 {
+		t.Errorf("Expected target HP 100, got %d", target.HP)
+	}
+}
+
+func TestCalculateDamage_SkillBonusTiers(t *testing.T) {
+	registry := NewEffectRegistry()
+	action := &ActionDefinition{
+		ID:         "test_attack",
+		Name:       "Test Attack",
+		BaseDamage: 100,
+	}
+
+	// Test each tier
+	tiers := []struct {
+		attackLevel   int
+		expectedBonus float64
+	}{
+		{25, 0.0},   // 0-25: 0%
+		{50, 0.10},  // 26-50: 10%
+		{75, 0.25},  // 51-75: 25%
+		{90, 0.50},  // 76-90: 50%
+		{99, 0.75},  // 91-99: 75%
+		{100, 1.0},  // 100: 100%
+	}
+
+	for _, tier := range tiers {
+		attacker := &Participant{ID: 1, Name: "Attacker", HP: 100, MaxHP: 100, Attack: tier.attackLevel}
+		defender := &Participant{ID: 2, Name: "Defender", HP: 100, MaxHP: 100, Defense: 0}
+
+		result := CalculateDamage(attacker, defender, action, registry)
+
+		if result.SkillBonus != tier.expectedBonus {
+			t.Errorf("Attack %d: expected skill bonus %.2f, got %.2f", tier.attackLevel, tier.expectedBonus, result.SkillBonus)
+		}
+	}
+}
+
+func TestDamageModifiers(t *testing.T) {
+	registry := NewEffectRegistry()
+	attacker := &Participant{ID: 1, Name: "Attacker", HP: 100, MaxHP: 100, Attack: 50}
+
+	// No buffs initially
+	damageBonus, _, _ := DamageModifiers(attacker.ID, registry)
+	if damageBonus != 0 {
+		t.Errorf("Expected 0 damage bonus without buffs, got %.2f", damageBonus)
+	}
+
+	// Apply strength buff
+	ApplyStatusEffect(registry, StatusBuffStrength, attacker.ID, attacker.ID)
+
+	damageBonus, _, accuracyMod := DamageModifiers(attacker.ID, registry)
+	if damageBonus != 0.25 {
+		t.Errorf("Expected 0.25 damage bonus with buff, got %.2f", damageBonus)
+	}
+	_ = accuracyMod
+}
+
+func TestCalculateEffectiveDefense(t *testing.T) {
+	registry := NewEffectRegistry()
+	participant := &Participant{ID: 1, Name: "Test", HP: 100, MaxHP: 100, Defense: 10}
+
+	defense := CalculateEffectiveDefense(participant, registry)
+	if defense != 10 {
+		t.Errorf("Expected defense 10, got %d", defense)
+	}
+}
+
+func TestCalculateEffectiveAttack(t *testing.T) {
+	registry := NewEffectRegistry()
+	participant := &Participant{ID: 1, Name: "Test", HP: 100, MaxHP: 100, Attack: 15}
+
+	attack := CalculateEffectiveAttack(participant, registry)
+	if attack != 15 {
+		t.Errorf("Expected attack 15, got %d", attack)
+	}
+}
+
+func TestDamageFormula_ExampleFromTicket(t *testing.T) {
+	// From ticket: Player with blades level 45, weapon damage 6
+	// Damage = 6 × (1 + 0.10) × (1 + 0.25) = 8.25 → 8
+	registry := NewEffectRegistry()
+
+	action := &ActionDefinition{
+		ID:         "slash",
+		Name:       "Slash",
+		BaseDamage: 6, // Scrap Machete
+	}
+
+	// Warrior with blades level 45 → 10% bonus (26-50 tier)
+	attacker := &Participant{ID: 1, Name: "Warrior", HP: 100, MaxHP: 100, Attack: 45}
+	defender := &Participant{ID: 2, Name: "Enemy", HP: 100, MaxHP: 100, Defense: 0}
+
+	// Apply battle cry buff (+25% damage)
+	ApplyStatusEffect(registry, StatusBuffStrength, attacker.ID, attacker.ID)
+
+	result := CalculateDamage(attacker, defender, action, registry)
+
+	// Skill bonus should be 0.10 (level 45 is in 26-50 tier)
+	if result.SkillBonus != 0.10 {
+		t.Errorf("Expected skill bonus 0.10, got %.2f", result.SkillBonus)
+	}
+
+	// Buff bonus should be 0.25
+	if result.BuffBonus != 0.25 {
+		t.Errorf("Expected buff bonus 0.25, got %.2f", result.BuffBonus)
+	}
+
+	// Raw damage: 6 * 1.10 * 1.25 = 8.25
+	// Floor to 8
+	if result.FinalDamage != 8 {
+		t.Errorf("Expected final damage 8, got %d", result.FinalDamage)
+	}
+}

--- a/herbst/combat/effect_registry.go
+++ b/herbst/combat/effect_registry.go
@@ -1,0 +1,269 @@
+package combat
+
+import (
+	"sync"
+	"time"
+)
+
+// EffectType defines the type of effect
+type EffectType string
+
+const (
+	// EffectDamage applies damage over time (DoT)
+	EffectDamage EffectType = "DAMAGE"
+	// EffectHeal applies healing over time (HoT)
+	EffectHeal EffectType = "HEAL"
+	// EffectBuff enhances a stat
+	EffectBuff EffectType = "BUFF"
+	// EffectDebuff reduces a stat
+	EffectDebuff EffectType = "DEBUFF"
+	// EffectStun prevents actions
+	EffectStun EffectType = "STUN"
+	// EffectRoot prevents movement
+	EffectRoot EffectType = "ROOT"
+	// EffectShield absorbs damage
+	EffectShield EffectType = "SHIELD"
+)
+
+// StatType defines which stat an effect modifies
+type StatType string
+
+const (
+	StatAttack   StatType = "ATTACK"
+	StatDefense  StatType = "DEFENSE"
+	StatSpeed    StatType = "SPEED"
+	StatDexterity StatType = "DEXTERITY"
+	StatManaRegen StatType = "MANA_REGEN"
+	StatHPRegen  StatType = "HP_REGEN"
+)
+
+// ActiveEffect represents an effect currently active on a participant
+type ActiveEffect struct {
+	ID           string      `json:"id"`
+	Name         string      `json:"name"`
+	Type         EffectType  `json:"type"`
+	TargetID     int         `json:"targetId"`
+	SourceID     int         `json:"sourceId"`
+
+	// Effect parameters
+	Value        int         `json:"value"`        // Damage/heal amount or stat modifier
+	Stat         StatType    `json:"stat"`         // Which stat to modify (for buffs/debuffs)
+
+	// Timing
+	TicksRemaining int        `json:"ticksRemaining"`
+	AppliedAt      time.Time  `json:"appliedAt"`
+
+	// Stacking
+	Stackable    bool        `json:"stackable"`
+	Stacks       int         `json:"stacks"`
+	MaxStacks    int         `json:"maxStacks"`
+
+	// Dispelling
+	Dispellable  bool        `json:"dispellable"`
+	DispelType  string      `json:"dispelType"` // "magic", "curse", "poison", etc.
+}
+
+// EffectRegistry manages all active effects in combat
+type EffectRegistry struct {
+	mu      sync.RWMutex
+	effects map[int][]*ActiveEffect // participantID -> effects
+}
+
+// NewEffectRegistry creates a new effect registry
+func NewEffectRegistry() *EffectRegistry {
+	return &EffectRegistry{
+		effects: make(map[int][]*ActiveEffect),
+	}
+}
+
+// ApplyEffect adds a new effect to a participant
+func (er *EffectRegistry) ApplyEffect(effect *ActiveEffect) {
+	er.mu.Lock()
+	defer er.mu.Unlock()
+
+	// Check for existing effect if not stackable
+	if !effect.Stackable {
+		for _, existing := range er.effects[effect.TargetID] {
+			if existing.ID == effect.ID {
+				// Refresh duration
+				existing.TicksRemaining = effect.TicksRemaining
+				return
+			}
+		}
+	}
+
+	er.effects[effect.TargetID] = append(er.effects[effect.TargetID], effect)
+}
+
+// RemoveEffect removes an effect from a participant
+func (er *EffectRegistry) RemoveEffect(participantID int, effectID string) {
+	er.mu.Lock()
+	defer er.mu.Unlock()
+
+	effects, exists := er.effects[participantID]
+	if !exists {
+		return
+	}
+
+	newEffects := make([]*ActiveEffect, 0)
+	for _, e := range effects {
+		if e.ID != effectID {
+			newEffects = append(newEffects, e)
+		}
+	}
+	er.effects[participantID] = newEffects
+}
+
+// RemoveAllEffects removes all effects from a participant
+func (er *EffectRegistry) RemoveAllEffects(participantID int) {
+	er.mu.Lock()
+	defer er.mu.Unlock()
+	delete(er.effects, participantID)
+}
+
+// GetEffectsForParticipant returns all effects on a participant
+func (er *EffectRegistry) GetEffectsForParticipant(participantID int) []*ActiveEffect {
+	er.mu.RLock()
+	defer er.mu.RUnlock()
+
+	effects, exists := er.effects[participantID]
+	if !exists {
+		return []*ActiveEffect{}
+	}
+	return effects
+}
+
+// GetEffectsByType returns all effects of a specific type on a participant
+func (er *EffectRegistry) GetEffectsByType(participantID int, effectType EffectType) []*ActiveEffect {
+	er.mu.RLock()
+	defer er.mu.RUnlock()
+
+	var result []*ActiveEffect
+	for _, e := range er.effects[participantID] {
+		if e.Type == effectType {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+// ProcessEffects processes all effects for a combat tick
+// Returns: (damageEffects, healEffects) for logging
+func (er *EffectRegistry) ProcessEffects(participants []*Participant) (damageEffects, healEffects []EffectResult) {
+	er.mu.Lock()
+	defer er.mu.Unlock()
+
+	for _, participant := range participants {
+		effects, exists := er.effects[participant.ID]
+		if !exists {
+			continue
+		}
+
+		var newEffects []*ActiveEffect
+		for _, effect := range effects {
+			// Apply effect
+			switch effect.Type {
+			case EffectDamage:
+				damageEffects = append(damageEffects, EffectResult{
+					Effect:  effect,
+					Target:  participant,
+					Value:   effect.Value * effect.Stacks,
+				})
+				participant.TakeDamage(effect.Value * effect.Stacks)
+			case EffectHeal:
+				healEffects = append(healEffects, EffectResult{
+					Effect:  effect,
+					Target:  participant,
+					Value:   effect.Value * effect.Stacks,
+				})
+				participant.Heal(effect.Value * effect.Stacks)
+			}
+
+			// Decrement duration
+			effect.TicksRemaining--
+			if effect.TicksRemaining > 0 {
+				newEffects = append(newEffects, effect)
+			}
+		}
+		er.effects[participant.ID] = newEffects
+	}
+
+	return damageEffects, healEffects
+}
+
+// GetStatModifier calculates the total stat modifier from buffs/debuffs
+func (er *EffectRegistry) GetStatModifier(participantID int, stat StatType) int {
+	er.mu.RLock()
+	defer er.mu.RUnlock()
+
+	total := 0
+	for _, effect := range er.effects[participantID] {
+		if effect.Stat == stat {
+			if effect.Type == EffectBuff {
+				total += effect.Value * effect.Stacks
+			} else if effect.Type == EffectDebuff {
+				total -= effect.Value * effect.Stacks
+			}
+		}
+	}
+	return total
+}
+
+// IsStunned returns true if the participant is stunned
+func (er *EffectRegistry) IsStunned(participantID int) bool {
+	er.mu.RLock()
+	defer er.mu.RUnlock()
+
+	for _, effect := range er.effects[participantID] {
+		// Check for STUNNED status effect
+		if effect.ID == string(StatusStunned) && effect.TicksRemaining > 0 {
+			return true
+		}
+		// Also check for generic EffectStun type
+		if effect.Type == EffectStun && effect.TicksRemaining > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// IsRooted returns true if the participant is rooted
+func (er *EffectRegistry) IsRooted(participantID int) bool {
+	er.mu.RLock()
+	defer er.mu.RUnlock()
+
+	for _, effect := range er.effects[participantID] {
+		if effect.Type == EffectRoot && effect.TicksRemaining > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// HasShield returns the total shield value
+func (er *EffectRegistry) HasShield(participantID int) int {
+	er.mu.RLock()
+	defer er.mu.RUnlock()
+
+	total := 0
+	for _, effect := range er.effects[participantID] {
+		if effect.Type == EffectShield && effect.TicksRemaining > 0 {
+			total += effect.Value * effect.Stacks
+		}
+	}
+	return total
+}
+
+// EffectResult represents the result of processing an effect
+type EffectResult struct {
+	Effect *ActiveEffect
+	Target *Participant
+	Value  int
+}
+
+// CountEffects returns the number of effects on a participant
+func (er *EffectRegistry) CountEffects(participantID int) int {
+	er.mu.RLock()
+	defer er.mu.RUnlock()
+	return len(er.effects[participantID])
+}

--- a/herbst/combat/effects.go
+++ b/herbst/combat/effects.go
@@ -1,0 +1,387 @@
+package combat
+
+import (
+	"fmt"
+	"time"
+)
+
+// StatusEffectType defines specific status effect types
+type StatusEffectType string
+
+const (
+	// DoT effects
+	StatusBleeding StatusEffectType = "BLEEDING" // 3 ticks, 1 dmg/tick
+	StatusPoison   StatusEffectType = "POISON"   // 5 ticks, 2 dmg/tick
+	StatusBurning  StatusEffectType = "BURNING"  // 4 ticks, 1 dmg/tick + -10% accuracy
+
+	// Control effects
+	StatusStunned  StatusEffectType = "STUNNED"  // 2 ticks, can't act
+	StatusBlinded  StatusEffectType = "BLINDED"  // 3 ticks, -50% accuracy
+
+	// Buff effects
+	StatusBuffStrength StatusEffectType = "BUFF_STRENGTH" // 5 ticks, +25% damage
+	StatusBuffShield   StatusEffectType = "BUFF_SHIELD"   // 3 ticks, -25% incoming damage
+)
+
+// StatusEffectDefinition defines a status effect's properties
+type StatusEffectDefinition struct {
+	ID          StatusEffectType `json:"id"`
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	Duration    int              `json:"defaultDuration"` // Default duration in ticks
+	DamagePerTick int            `json:"damagePerTick"`
+	HealPerTick   int            `json:"healPerTick"`
+	
+	// Stat modifiers
+	AccuracyMod   float64 `json:"accuracyMod"`   // -0.50 for -50%
+	DamageMod     float64 `json:"damageMod"`     // +0.25 for +25%
+	IncomingDamageMod float64 `json:"incomingDamageMod"` // -0.25 for -25%
+	
+	// Flags
+	PreventsAction bool `json:"preventsAction"` // Stunned, etc.
+	IsDoT          bool `json:"isDoT"`
+	IsDebuff      bool `json:"isDebuff"`
+	IsBuff        bool `json:"isBuff"`
+	Dispellable   bool `json:"dispellable"`
+}
+
+// StatusEffectDefinitions holds all status effect definitions
+var StatusEffectDefinitions = map[StatusEffectType]*StatusEffectDefinition{
+	StatusBleeding: {
+		ID:            StatusBleeding,
+		Name:          "Bleeding",
+		Description:   "Taking 1 damage per tick from blood loss.",
+		Duration:      3,
+		DamagePerTick: 1,
+		IsDoT:         true,
+		IsDebuff:      true,
+		Dispellable:   true,
+	},
+	StatusPoison: {
+		ID:            StatusPoison,
+		Name:          "Poisoned",
+		Description:   "Taking 2 damage per tick from poison.",
+		Duration:      5,
+		DamagePerTick: 2,
+		IsDoT:         true,
+		IsDebuff:      true,
+		Dispellable:   true,
+	},
+	StatusBurning: {
+		ID:            StatusBurning,
+		Name:          "Burning",
+		Description:   "Taking 1 damage per tick and -10% accuracy from flames.",
+		Duration:      4,
+		DamagePerTick: 1,
+		AccuracyMod:   -0.10,
+		IsDoT:         true,
+		IsDebuff:      true,
+		Dispellable:   true,
+	},
+	StatusStunned: {
+		ID:             StatusStunned,
+		Name:           "Stunned",
+		Description:    "Cannot take any actions.",
+		Duration:       2,
+		PreventsAction: true,
+		IsDebuff:       true,
+		Dispellable:    true,
+	},
+	StatusBlinded: {
+		ID:           StatusBlinded,
+		Name:         "Blinded",
+		Description:  "-50% accuracy due to impaired vision.",
+		Duration:     3,
+		AccuracyMod: -0.50,
+		IsDebuff:     true,
+		Dispellable:  true,
+	},
+	StatusBuffStrength: {
+		ID:        StatusBuffStrength,
+		Name:      "Strength Buff",
+		Description: "+25% damage from battle rage.",
+		Duration:  5,
+		DamageMod: 0.25,
+		IsBuff:    true,
+	},
+	StatusBuffShield: {
+		ID:                StatusBuffShield,
+		Name:              "Shielded",
+		Description:       "-25% incoming damage from protective barrier.",
+		Duration:          3,
+		IncomingDamageMod: -0.25,
+		IsBuff:            true,
+	},
+}
+
+// CreateStatusEffect creates a new active status effect
+func CreateStatusEffect(effectType StatusEffectType, targetID, sourceID int) *ActiveEffect {
+	def, exists := StatusEffectDefinitions[effectType]
+	if !exists {
+		return nil
+	}
+
+	return &ActiveEffect{
+		ID:             string(effectType),
+		Name:           def.Name,
+		Type:           mapEffectType(def),
+		TargetID:       targetID,
+		SourceID:       sourceID,
+		Value:          def.DamagePerTick,
+		TicksRemaining: def.Duration,
+		AppliedAt:      time.Now(),
+		Stackable:      false,
+		Stacks:         1,
+		Dispellable:    def.Dispellable,
+	}
+}
+
+// mapEffectType converts StatusEffectType to EffectType for the registry
+func mapEffectType(def *StatusEffectDefinition) EffectType {
+	if def.IsDoT {
+		return EffectDamage
+	}
+	if def.IsBuff {
+		return EffectBuff
+	}
+	if def.IsDebuff {
+		return EffectDebuff
+	}
+	if def.PreventsAction {
+		return EffectStun
+	}
+	return EffectDebuff
+}
+
+// ApplyStatusEffect applies a status effect to a participant
+func ApplyStatusEffect(registry *EffectRegistry, effectType StatusEffectType, targetID, sourceID int) *ActiveEffect {
+	effect := CreateStatusEffect(effectType, targetID, sourceID)
+	if effect == nil {
+		return nil
+	}
+	registry.ApplyEffect(effect)
+	return effect
+}
+
+// ProcessStatusEffectTick processes a single status effect for one tick
+func ProcessStatusEffectTick(effect *ActiveEffect, target *Participant) (damageDealt int, action string) {
+	def, exists := StatusEffectDefinitions[StatusEffectType(effect.ID)]
+	if !exists {
+		return 0, ""
+	}
+
+	// Apply DoT damage
+	if def.IsDoT && def.DamagePerTick > 0 {
+		damageDealt = def.DamagePerTick * effect.Stacks
+		target.TakeDamage(damageDealt)
+		action = fmt.Sprintf("%s takes %d %s damage", target.Name, damageDealt, def.Name)
+	}
+
+	// Stun prevents actions
+	if def.PreventsAction {
+		action = fmt.Sprintf("%s is stunned and cannot act", target.Name)
+	}
+
+	return damageDealt, action
+}
+
+// GetAccuracyModifier returns the total accuracy modifier from all effects
+func GetAccuracyModifier(registry *EffectRegistry, participantID int) float64 {
+	effects := registry.GetEffectsForParticipant(participantID)
+	totalMod := 0.0
+
+	for _, effect := range effects {
+		def, exists := StatusEffectDefinitions[StatusEffectType(effect.ID)]
+		if exists {
+			totalMod += def.AccuracyMod
+		}
+	}
+
+	return totalMod
+}
+
+// GetDamageModifier returns the total damage modifier from all effects (buffs)
+func GetDamageModifier(registry *EffectRegistry, participantID int) float64 {
+	effects := registry.GetEffectsForParticipant(participantID)
+	totalMod := 0.0
+
+	for _, effect := range effects {
+		def, exists := StatusEffectDefinitions[StatusEffectType(effect.ID)]
+		if exists && effect.TicksRemaining > 0 {
+			totalMod += def.DamageMod
+		}
+	}
+
+	return totalMod
+}
+
+// GetIncomingDamageModifier returns the modifier for incoming damage (shields)
+func GetIncomingDamageModifier(registry *EffectRegistry, participantID int) float64 {
+	effects := registry.GetEffectsForParticipant(participantID)
+	totalMod := 0.0
+
+	for _, effect := range effects {
+		def, exists := StatusEffectDefinitions[StatusEffectType(effect.ID)]
+		if exists && effect.TicksRemaining > 0 {
+			totalMod += def.IncomingDamageMod
+		}
+	}
+
+	return totalMod
+}
+
+// CanAct returns false if the participant is stunned or otherwise prevented from acting
+func CanAct(registry *EffectRegistry, participantID int) bool {
+	return !registry.IsStunned(participantID)
+}
+
+// GetActiveStatusEffects returns all active status effects with their definitions
+func GetActiveStatusEffects(registry *EffectRegistry, participantID int) []StatusEffectInstance {
+	effects := registry.GetEffectsForParticipant(participantID)
+	instances := make([]StatusEffectInstance, 0, len(effects))
+
+	for _, effect := range effects {
+		def, exists := StatusEffectDefinitions[StatusEffectType(effect.ID)]
+		if exists {
+			instances = append(instances, StatusEffectInstance{
+				Definition:     def,
+				ActiveEffect:   effect,
+				TicksRemaining: effect.TicksRemaining,
+			})
+		}
+	}
+
+	return instances
+}
+
+// StatusEffectInstance combines a definition with its active state
+type StatusEffectInstance struct {
+	Definition     *StatusEffectDefinition
+	ActiveEffect   *ActiveEffect
+	TicksRemaining int
+}
+
+// ProcessAllStatusEffects processes all status effects for a tick
+// This applies DoT damage and decrements durations
+func ProcessAllStatusEffects(registry *EffectRegistry, participants []*Participant) []StatusEffectLog {
+	var logs []StatusEffectLog
+
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	for _, participant := range participants {
+		effects, exists := registry.effects[participant.ID]
+		if !exists {
+			continue
+		}
+
+		var remainingEffects []*ActiveEffect
+		for _, effect := range effects {
+			// Get definition for this effect
+			def, exists := StatusEffectDefinitions[StatusEffectType(effect.ID)]
+			if !exists {
+				// Not a status effect, keep it
+				remainingEffects = append(remainingEffects, effect)
+				continue
+			}
+
+			// Apply DoT damage
+			var damageDealt int
+			var action string
+			if def.IsDoT && def.DamagePerTick > 0 {
+				damageDealt = def.DamagePerTick * effect.Stacks
+				participant.TakeDamage(damageDealt)
+				action = fmt.Sprintf("%s takes %d %s damage", participant.Name, damageDealt, def.Name)
+			}
+
+			// Log stun
+			if def.PreventsAction {
+				action = fmt.Sprintf("%s is stunned and cannot act", participant.Name)
+			}
+
+			// Log effect
+			if action != "" {
+				logs = append(logs, StatusEffectLog{
+					TargetID:    participant.ID,
+					TargetName:  participant.Name,
+					EffectID:    effect.ID,
+					EffectName:  effect.Name,
+					DamageDealt: damageDealt,
+					Action:      action,
+					Tick:        effect.TicksRemaining - 1, // After this tick
+				})
+			}
+
+			// Decrement duration
+			effect.TicksRemaining--
+			if effect.TicksRemaining > 0 {
+				remainingEffects = append(remainingEffects, effect)
+			}
+		}
+		registry.effects[participant.ID] = remainingEffects
+	}
+
+	return logs
+}
+
+// StatusEffectLog represents a log entry for status effect processing
+type StatusEffectLog struct {
+	TargetID    int    `json:"targetId"`
+	TargetName  string `json:"targetName"`
+	EffectID    string `json:"effectId"`
+	EffectName  string `json:"effectName"`
+	DamageDealt int    `json:"damageDealt"`
+	Action      string `json:"action"`
+	Tick        int    `json:"tick"` // Ticks remaining after processing
+}
+
+// GetStatusEffectDefinition retrieves a status effect definition
+func GetStatusEffectDefinition(effectType StatusEffectType) (*StatusEffectDefinition, bool) {
+	def, exists := StatusEffectDefinitions[effectType]
+	return def, exists
+}
+
+// ListAllStatusEffects returns all available status effect definitions
+func ListAllStatusEffects() []*StatusEffectDefinition {
+	defs := make([]*StatusEffectDefinition, 0, len(StatusEffectDefinitions))
+	for _, def := range StatusEffectDefinitions {
+		defs = append(defs, def)
+	}
+	return defs
+}
+
+// IsDebuff checks if a status effect is a debuff
+func IsDebuff(effectType StatusEffectType) bool {
+	def, exists := StatusEffectDefinitions[effectType]
+	if !exists {
+		return false
+	}
+	return def.IsDebuff
+}
+
+// IsBuff checks if a status effect is a buff
+func IsBuff(effectType StatusEffectType) bool {
+	def, exists := StatusEffectDefinitions[effectType]
+	if !exists {
+		return false
+	}
+	return def.IsBuff
+}
+
+// IsDoT checks if a status effect is damage over time
+func IsDoT(effectType StatusEffectType) bool {
+	def, exists := StatusEffectDefinitions[effectType]
+	if !exists {
+		return false
+	}
+	return def.IsDoT
+}
+
+// PreventsAction checks if a status effect prevents actions
+func PreventsAction(effectType StatusEffectType) bool {
+	def, exists := StatusEffectDefinitions[effectType]
+	if !exists {
+		return false
+	}
+	return def.PreventsAction
+}

--- a/herbst/combat/effects_test.go
+++ b/herbst/combat/effects_test.go
@@ -1,0 +1,393 @@
+package combat
+
+import (
+	"testing"
+)
+
+func TestCreateStatusEffect_Bleeding(t *testing.T) {
+	effect := CreateStatusEffect(StatusBleeding, 1, 2)
+
+	if effect == nil {
+		t.Fatal("Expected effect, got nil")
+	}
+	if effect.Name != "Bleeding" {
+		t.Errorf("Expected name 'Bleeding', got '%s'", effect.Name)
+	}
+	if effect.TicksRemaining != 3 {
+		t.Errorf("Expected 3 ticks, got %d", effect.TicksRemaining)
+	}
+	if effect.Value != 1 {
+		t.Errorf("Expected 1 damage per tick, got %d", effect.Value)
+	}
+	if effect.TargetID != 1 {
+		t.Errorf("Expected target ID 1, got %d", effect.TargetID)
+	}
+}
+
+func TestCreateStatusEffect_Poison(t *testing.T) {
+	effect := CreateStatusEffect(StatusPoison, 1, 2)
+
+	if effect == nil {
+		t.Fatal("Expected effect, got nil")
+	}
+	if effect.Name != "Poisoned" {
+		t.Errorf("Expected name 'Poisoned', got '%s'", effect.Name)
+	}
+	if effect.TicksRemaining != 5 {
+		t.Errorf("Expected 5 ticks, got %d", effect.TicksRemaining)
+	}
+	if effect.Value != 2 {
+		t.Errorf("Expected 2 damage per tick, got %d", effect.Value)
+	}
+}
+
+func TestCreateStatusEffect_Stunned(t *testing.T) {
+	effect := CreateStatusEffect(StatusStunned, 1, 2)
+
+	if effect == nil {
+		t.Fatal("Expected effect, got nil")
+	}
+	if effect.Name != "Stunned" {
+		t.Errorf("Expected name 'Stunned', got '%s'", effect.Name)
+	}
+	if effect.TicksRemaining != 2 {
+		t.Errorf("Expected 2 ticks, got %d", effect.TicksRemaining)
+	}
+}
+
+func TestCreateStatusEffect_BuffStrength(t *testing.T) {
+	effect := CreateStatusEffect(StatusBuffStrength, 1, 2)
+
+	if effect == nil {
+		t.Fatal("Expected effect, got nil")
+	}
+	if effect.Name != "Strength Buff" {
+		t.Errorf("Expected name 'Strength Buff', got '%s'", effect.Name)
+	}
+	if effect.TicksRemaining != 5 {
+		t.Errorf("Expected 5 ticks, got %d", effect.TicksRemaining)
+	}
+}
+
+func TestApplyStatusEffect(t *testing.T) {
+	registry := NewEffectRegistry()
+
+	effect := ApplyStatusEffect(registry, StatusBleeding, 1, 2)
+
+	if effect == nil {
+		t.Fatal("Expected effect, got nil")
+	}
+
+	effects := registry.GetEffectsForParticipant(1)
+	if len(effects) != 1 {
+		t.Errorf("Expected 1 effect, got %d", len(effects))
+	}
+	if effects[0].Name != "Bleeding" {
+		t.Errorf("Expected 'Bleeding', got '%s'", effects[0].Name)
+	}
+}
+
+func TestProcessStatusEffectTick_Damage(t *testing.T) {
+	effect := CreateStatusEffect(StatusBleeding, 1, 2)
+	target := &Participant{
+		ID:     1,
+		Name:   "Test Target",
+		HP:     30,
+		MaxHP:  30,
+		IsAlive: true,
+	}
+
+	damage, action := ProcessStatusEffectTick(effect, target)
+
+	if damage != 1 {
+		t.Errorf("Expected 1 damage, got %d", damage)
+	}
+	if action == "" {
+		t.Error("Expected action description, got empty string")
+	}
+	if target.HP != 29 {
+		t.Errorf("Expected HP 29 after bleed, got %d", target.HP)
+	}
+}
+
+func TestProcessStatusEffectTick_Stun(t *testing.T) {
+	effect := CreateStatusEffect(StatusStunned, 1, 2)
+	target := &Participant{
+		ID:      1,
+		Name:    "Test Target",
+		HP:      30,
+		MaxHP:   30,
+		IsAlive: true,
+	}
+
+	damage, action := ProcessStatusEffectTick(effect, target)
+
+	if damage != 0 {
+		t.Errorf("Expected 0 damage for stun, got %d", damage)
+	}
+	if action == "" {
+		t.Error("Expected stun action description")
+	}
+	if target.HP != 30 {
+		t.Errorf("Stun should not deal damage, HP should be 30, got %d", target.HP)
+	}
+}
+
+func TestGetAccuracyModifier(t *testing.T) {
+	registry := NewEffectRegistry()
+
+	// Apply Blinded effect (-50% accuracy)
+	ApplyStatusEffect(registry, StatusBlinded, 1, 2)
+
+	mod := GetAccuracyModifier(registry, 1)
+	if mod != -0.50 {
+		t.Errorf("Expected -0.50 accuracy mod, got %.2f", mod)
+	}
+
+	// Apply Burning (-10% accuracy)
+	ApplyStatusEffect(registry, StatusBurning, 1, 2)
+
+	mod = GetAccuracyModifier(registry, 1)
+	if mod != -0.60 {
+		t.Errorf("Expected -0.60 combined accuracy mod, got %.2f", mod)
+	}
+}
+
+func TestGetDamageModifier(t *testing.T) {
+	registry := NewEffectRegistry()
+
+	// Apply Strength buff (+25% damage)
+	ApplyStatusEffect(registry, StatusBuffStrength, 1, 2)
+
+	mod := GetDamageModifier(registry, 1)
+	if mod != 0.25 {
+		t.Errorf("Expected 0.25 damage mod, got %.2f", mod)
+	}
+}
+
+func TestGetIncomingDamageModifier(t *testing.T) {
+	registry := NewEffectRegistry()
+
+	// Apply Shield buff (-25% incoming damage)
+	ApplyStatusEffect(registry, StatusBuffShield, 1, 2)
+
+	mod := GetIncomingDamageModifier(registry, 1)
+	if mod != -0.25 {
+		t.Errorf("Expected -0.25 incoming damage mod, got %.2f", mod)
+	}
+}
+
+func TestCanAct_Stunned(t *testing.T) {
+	registry := NewEffectRegistry()
+
+	// Without stun, can act
+	if !CanAct(registry, 1) {
+		t.Error("Expected to be able to act without stun")
+	}
+
+	// Apply stun
+	ApplyStatusEffect(registry, StatusStunned, 1, 2)
+
+	// With stun, cannot act
+	if CanAct(registry, 1) {
+		t.Error("Expected to NOT be able to act while stunned")
+	}
+}
+
+func TestProcessAllStatusEffects(t *testing.T) {
+	registry := NewEffectRegistry()
+	participants := []*Participant{
+		{ID: 1, Name: "Player", HP: 30, MaxHP: 30, IsAlive: true},
+		{ID: 2, Name: "Enemy", HP: 20, MaxHP: 20, IsAlive: true},
+	}
+
+	// Apply bleed to player (1 damage/tick)
+	ApplyStatusEffect(registry, StatusBleeding, 1, 2)
+	// Apply poison to enemy (2 damage/tick)
+	ApplyStatusEffect(registry, StatusPoison, 2, 1)
+
+	logs := ProcessAllStatusEffects(registry, participants)
+
+	if len(logs) != 2 {
+		t.Errorf("Expected 2 log entries, got %d", len(logs))
+	}
+
+	// Check player took bleed damage (1 dmg)
+	if participants[0].HP != 29 {
+		t.Errorf("Expected player HP 29 after bleed, got %d", participants[0].HP)
+	}
+
+	// Check enemy took poison damage (2 dmg)
+	if participants[1].HP != 18 {
+		t.Errorf("Expected enemy HP 18 after poison, got %d", participants[1].HP)
+	}
+}
+
+func TestStatusEffectDuration(t *testing.T) {
+	registry := NewEffectRegistry()
+
+	// Apply 3-tick bleeding
+	ApplyStatusEffect(registry, StatusBleeding, 1, 2)
+
+	participant := &Participant{ID: 1, Name: "Test", HP: 30, MaxHP: 30, IsAlive: true}
+	participants := []*Participant{participant}
+
+	// Tick 1
+	ProcessAllStatusEffects(registry, participants)
+	effects := registry.GetEffectsForParticipant(1)
+	if len(effects) != 1 {
+		t.Errorf("Expected effect to remain after tick 1, got %d effects", len(effects))
+	}
+	if effects[0].TicksRemaining != 2 {
+		t.Errorf("Expected 2 ticks remaining, got %d", effects[0].TicksRemaining)
+	}
+
+	// Tick 2
+	ProcessAllStatusEffects(registry, participants)
+	effects = registry.GetEffectsForParticipant(1)
+	if len(effects) != 1 {
+		t.Errorf("Expected effect to remain after tick 2, got %d effects", len(effects))
+	}
+
+	// Tick 3
+	ProcessAllStatusEffects(registry, participants)
+	effects = registry.GetEffectsForParticipant(1)
+	if len(effects) != 0 {
+		t.Errorf("Expected effect to be removed after tick 3, got %d effects", len(effects))
+	}
+}
+
+func TestStatusEffectNoRefresh(t *testing.T) {
+	registry := NewEffectRegistry()
+
+	// Apply bleeding
+	ApplyStatusEffect(registry, StatusBleeding, 1, 2)
+	effects := registry.GetEffectsForParticipant(1)
+	if len(effects) != 1 {
+		t.Errorf("Expected 1 effect, got %d", len(effects))
+	}
+	firstEffect := effects[0]
+
+	// Apply same effect again - should refresh duration, not stack
+	ApplyStatusEffect(registry, StatusBleeding, 1, 2)
+	effects = registry.GetEffectsForParticipant(1)
+	if len(effects) != 1 {
+		t.Errorf("Expected 1 effect (refreshed), got %d", len(effects))
+	}
+	if effects[0] != firstEffect {
+		t.Error("Effect should be same instance (refreshed)")
+	}
+	if effects[0].TicksRemaining != 3 {
+		t.Errorf("Expected refreshed duration of 3, got %d", effects[0].TicksRemaining)
+	}
+}
+
+func TestStatusEffectDefinitions(t *testing.T) {
+	// Test all status effects are defined
+	expectedEffects := []StatusEffectType{
+		StatusBleeding, StatusPoison, StatusBurning,
+		StatusStunned, StatusBlinded,
+		StatusBuffStrength, StatusBuffShield,
+	}
+
+	for _, effectType := range expectedEffects {
+		def, exists := GetStatusEffectDefinition(effectType)
+		if !exists {
+			t.Errorf("Status effect '%s' not defined", effectType)
+			continue
+		}
+		if def.Name == "" {
+			t.Errorf("Status effect '%s' has no name", effectType)
+		}
+		if def.Duration <= 0 {
+			t.Errorf("Status effect '%s' has invalid duration: %d", effectType, def.Duration)
+		}
+	}
+}
+
+func TestIsDebuff(t *testing.T) {
+	if !IsDebuff(StatusBleeding) {
+		t.Error("Bleeding should be a debuff")
+	}
+	if !IsDebuff(StatusPoison) {
+		t.Error("Poison should be a debuff")
+	}
+	if !IsDebuff(StatusStunned) {
+		t.Error("Stunned should be a debuff")
+	}
+	if IsDebuff(StatusBuffStrength) {
+		t.Error("BuffStrength should NOT be a debuff")
+	}
+}
+
+func TestIsBuff(t *testing.T) {
+	if !IsBuff(StatusBuffStrength) {
+		t.Error("BuffStrength should be a buff")
+	}
+	if !IsBuff(StatusBuffShield) {
+		t.Error("BuffShield should be a buff")
+	}
+	if IsBuff(StatusPoison) {
+		t.Error("Poison should NOT be a buff")
+	}
+}
+
+func TestIsDoT(t *testing.T) {
+	if !IsDoT(StatusBleeding) {
+		t.Error("Bleeding should be DoT")
+	}
+	if !IsDoT(StatusPoison) {
+		t.Error("Poison should be DoT")
+	}
+	if !IsDoT(StatusBurning) {
+		t.Error("Burning should be DoT")
+	}
+	if IsDoT(StatusStunned) {
+		t.Error("Stunned should NOT be DoT")
+	}
+}
+
+func TestPreventsAction(t *testing.T) {
+	if !PreventsAction(StatusStunned) {
+		t.Error("Stunned should prevent actions")
+	}
+	if PreventsAction(StatusPoison) {
+		t.Error("Poison should NOT prevent actions")
+	}
+}
+
+func TestListAllStatusEffects(t *testing.T) {
+	effects := ListAllStatusEffects()
+	if len(effects) != 7 {
+		t.Errorf("Expected 7 status effects, got %d", len(effects))
+	}
+}
+
+func TestGetActiveStatusEffects(t *testing.T) {
+	registry := NewEffectRegistry()
+
+	// No effects initially
+	instances := GetActiveStatusEffects(registry, 1)
+	if len(instances) != 0 {
+		t.Errorf("Expected 0 active effects, got %d", len(instances))
+	}
+
+	// Apply multiple effects
+	ApplyStatusEffect(registry, StatusBleeding, 1, 2)
+	ApplyStatusEffect(registry, StatusBuffStrength, 1, 2)
+
+	instances = GetActiveStatusEffects(registry, 1)
+	if len(instances) != 2 {
+		t.Errorf("Expected 2 active effects, got %d", len(instances))
+	}
+
+	// Check each has definition
+	for _, inst := range instances {
+		if inst.Definition == nil {
+			t.Error("Expected definition, got nil")
+		}
+		if inst.ActiveEffect == nil {
+			t.Error("Expected active effect, got nil")
+		}
+	}
+}

--- a/herbst/combat/enemy_ai.go
+++ b/herbst/combat/enemy_ai.go
@@ -1,0 +1,320 @@
+package combat
+
+import (
+	"context"
+	"math/rand"
+)
+
+// EnemyAI defines the interface for enemy AI decision making
+type EnemyAI interface {
+	// Decide chooses an action for the enemy to take
+	Decide(ctx context.Context, combat *Combat, self *Participant) *AIAction
+}
+
+// AIAction represents an AI's chosen action
+type AIAction struct {
+	ActionID   string      `json:"actionId"`   // Action to perform (attack, defend, flee, etc.)
+	TargetID   int         `json:"targetId"`   // Target participant ID (if single target)
+	TargetIDs  []int       `json:"targetIds"`  // Target IDs (if multi-target)
+	Priority   int         `json:"priority"`   // Decision priority (higher = more urgent)
+	Reason     string      `json:"reason"`     // Why this action was chosen
+}
+
+// BasicEnemyAI implements basic enemy AI behavior
+type BasicEnemyAI struct {
+	// FleeThreshold is the HP percentage below which flee is considered (0.0-1.0)
+	FleeThreshold float64
+	// HealThreshold is the HP percentage below which heal abilities are prioritized
+	HealThreshold float64
+	// Aggression controls tendency to use offensive abilities (0.0-1.0)
+	Aggression float64
+	// Abilities available to this enemy
+	Abilities []string
+}
+
+// NewBasicEnemyAI creates a basic enemy AI with default settings
+func NewBasicEnemyAI() *BasicEnemyAI {
+	return &BasicEnemyAI{
+		FleeThreshold: 0.25,  // 25% HP
+		HealThreshold: 0.30,  // 30% HP
+		Aggression:     0.7,  // 70% chance to use offensive abilities
+		Abilities:      []string{},
+	}
+}
+
+// Decide implements EnemyAI.Decide
+func (ai *BasicEnemyAI) Decide(ctx context.Context, combat *Combat, self *Participant) *AIAction {
+	// Get current HP percentage
+	hpPercent := float64(self.HP) / float64(self.MaxHP)
+
+	// 1. HEALTH CHECK - Flee or heal if critically low
+	if hpPercent < ai.FleeThreshold {
+		// Try to flee based on DEX
+		fleeChance := float64(self.Dexterity) / 100.0
+		if rand.Float64() < fleeChance {
+			return &AIAction{
+				ActionID: "flee",
+				Priority: 100,
+				Reason:   "low_hp_flee",
+			}
+		}
+
+		// Check for heal abilities
+		healAction := ai.findHealAbility()
+		if healAction != nil {
+			return healAction
+		}
+	}
+
+	// 2. ABILITY CHECK - Use special abilities when ready
+	if len(ai.Abilities) > 0 && rand.Float64() < ai.Aggression {
+		abilityAction := ai.chooseAbility(combat, self)
+		if abilityAction != nil {
+			return abilityAction
+		}
+	}
+
+	// 3. BASIC ATTACK - Fallback to basic attack
+	return ai.basicAttack(combat, self)
+}
+
+// findHealAbility searches for a heal ability the enemy can use
+func (ai *BasicEnemyAI) findHealAbility() *AIAction {
+	for _, abilityID := range ai.Abilities {
+		action, exists := GetActionDefinition(abilityID)
+		if !exists {
+			continue
+		}
+		if action.BaseHeal > 0 && action.Cooldown == 0 {
+			return &AIAction{
+				ActionID: abilityID,
+				Priority: 90,
+				Reason:   "low_hp_heal",
+			}
+		}
+	}
+	return nil
+}
+
+// chooseAbility selects the best ability to use
+func (ai *BasicEnemyAI) chooseAbility(combat *Combat, self *Participant) *AIAction {
+	// Get list of alive enemies (players)
+	enemies := combat.GetAliveByTeam(0) // Team 0 = players
+	if len(enemies) == 0 {
+		return nil
+	}
+
+	// Find the highest damage ability ready to use
+	var bestAbility string
+	var bestDamage int
+	for _, abilityID := range ai.Abilities {
+		action, exists := GetActionDefinition(abilityID)
+		if !exists {
+			continue
+		}
+		// Skip heal abilities here (handled separately)
+		if action.BaseHeal > 0 {
+			continue
+		}
+		if action.BaseDamage > bestDamage {
+			bestAbility = abilityID
+			bestDamage = action.BaseDamage
+		}
+	}
+
+	if bestAbility != "" {
+		// Target the player with lowest HP (focus fire)
+		target := ai.findWeakestTarget(enemies)
+		return &AIAction{
+			ActionID: bestAbility,
+			TargetID: target.ID,
+			Priority: 70,
+			Reason:   "ability_offensive",
+		}
+	}
+
+	return nil
+}
+
+// basicAttack returns a basic attack action
+func (ai *BasicEnemyAI) basicAttack(combat *Combat, self *Participant) *AIAction {
+	enemies := combat.GetAliveByTeam(0)
+	if len(enemies) == 0 {
+		return nil
+	}
+
+	// Target the player with lowest HP
+	target := ai.findWeakestTarget(enemies)
+
+	return &AIAction{
+		ActionID: "attack",
+		TargetID: target.ID,
+		Priority: 50,
+		Reason:   "basic_attack",
+	}
+}
+
+// findWeakestTarget finds the target with the lowest HP percentage
+func (ai *BasicEnemyAI) findWeakestTarget(targets []*Participant) *Participant {
+	if len(targets) == 0 {
+		return nil
+	}
+
+	weakest := targets[0]
+	weakestPercent := float64(weakest.HP) / float64(weakest.MaxHP)
+
+	for _, t := range targets[1:] {
+		percent := float64(t.HP) / float64(t.MaxHP)
+		if percent < weakestPercent {
+			weakest = t
+			weakestPercent = percent
+		}
+	}
+
+	return weakest
+}
+
+// EnemyDefinition defines an enemy type's stats and behavior
+type EnemyDefinition struct {
+	ID             string      `json:"id"`
+	Name           string      `json:"name"`
+	HP             int         `json:"hp"`
+	Attack         int         `json:"attack"`
+	Defense        int         `json:"defense"`
+	Dexterity      int         `json:"dexterity"`
+	AttackTick     int         `json:"attackTick"`     // Ticks for basic attack
+	SpecialTick    int         `json:"specialTick"`    // Ticks for special ability (0 if none)
+	SpecialName    string      `json:"specialName"`    // Name of special ability
+	SpecialDamage  int         `json:"specialDamage"`  // Damage of special ability
+	SpecialCooldown int        `json:"specialCooldown"` // Cooldown for special
+	FleeChance     float64     `json:"fleeChance"`     // Base flee chance when low HP
+	AI             EnemyAI     `json:"-"`              // AI implementation
+	Abilities      []string    `json:"abilities"`      // Ability IDs available
+}
+
+// EnemyRegistry holds all enemy definitions
+var EnemyRegistry = map[string]*EnemyDefinition{
+	"scrap_rat": {
+		ID:         "scrap_rat",
+		Name:       "Scrap Rat",
+		HP:         15,
+		Attack:     5,
+		Defense:    2,
+		Dexterity:  8,
+		AttackTick: 1,
+		FleeChance: 0.20,
+		AI: &BasicEnemyAI{
+			FleeThreshold: 0.25,
+			Aggression:    0.5,
+			Abilities:     []string{},
+		},
+	},
+	"junk_dog": {
+		ID:              "junk_dog",
+		Name:            "Junk Dog",
+		HP:              25,
+		Attack:          8,
+		Defense:         4,
+		Dexterity:       6,
+		AttackTick:      1,
+		SpecialTick:     1,
+		SpecialName:     "Bite",
+		SpecialDamage:   8,
+		SpecialCooldown: 3,
+		FleeChance:      0.15,
+		Abilities:       []string{"bite"},
+		AI: &BasicEnemyAI{
+			FleeThreshold: 0.25,
+			Aggression:    0.7,
+			Abilities:     []string{"bite"},
+		},
+	},
+	"ooze_spawn": {
+		ID:              "ooze_spawn",
+		Name:            "Ooze Spawn",
+		HP:              20,
+		Attack:          6,
+		Defense:         3,
+		Dexterity:       4,
+		AttackTick:      1,
+		SpecialTick:     3,
+		SpecialName:     "Explode",
+		SpecialDamage:   15,
+		SpecialCooldown: 0, // One-time use
+		FleeChance:      0.10,
+		Abilities:       []string{"explode"},
+		AI: &BasicEnemyAI{
+			FleeThreshold: 0.20,
+			Aggression:    0.9,
+			Abilities:     []string{"explode"},
+		},
+	},
+	"old_scrap": {
+		ID:              "old_scrap",
+		Name:            "Old Scrap",
+		HP:              40,
+		Attack:          12,
+		Defense:         8,
+		Dexterity:       5,
+		AttackTick:      1,
+		SpecialTick:     2,
+		SpecialName:     "Crush",
+		SpecialDamage:   12,
+		SpecialCooldown: 2,
+		FleeChance:      0.25,
+		Abilities:       []string{"crush", "scavenge"},
+		AI: &BasicEnemyAI{
+			FleeThreshold: 0.30,
+			HealThreshold: 0.35,
+			Aggression:    0.8,
+			Abilities:     []string{"crush", "scavenge"},
+		},
+	},
+}
+
+// GetEnemyDefinition retrieves an enemy definition by ID
+func GetEnemyDefinition(id string) (*EnemyDefinition, bool) {
+	def, exists := EnemyRegistry[id]
+	return def, exists
+}
+
+// CreateParticipantFromEnemy creates a combat participant from an enemy definition
+func CreateParticipantFromEnemy(enemyID string, id int) *Participant {
+	def, exists := GetEnemyDefinition(enemyID)
+	if !exists {
+		return nil
+	}
+
+	return &Participant{
+		ID:         id,
+		Name:       def.Name,
+		IsPlayer:   false,
+		IsNPC:      true,
+		HP:         def.HP,
+		MaxHP:      def.HP,
+		Attack:     def.Attack,
+		Defense:    def.Defense,
+		Dexterity:  def.Dexterity,
+		IsAlive:    true,
+		IsActive:   true,
+		Team:       1, // Enemy team
+	}
+}
+
+// GetAIAction returns the AI's chosen action for this enemy
+func GetAIAction(enemyID string, combat *Combat, self *Participant) *AIAction {
+	def, exists := GetEnemyDefinition(enemyID)
+	if !exists {
+		// Fallback to basic AI
+		ai := NewBasicEnemyAI()
+		return ai.Decide(nil, combat, self)
+	}
+
+	if def.AI != nil {
+		return def.AI.Decide(nil, combat, self)
+	}
+
+	// Default AI
+	ai := NewBasicEnemyAI()
+	return ai.Decide(nil, combat, self)
+}

--- a/herbst/combat/enemy_ai_test.go
+++ b/herbst/combat/enemy_ai_test.go
@@ -1,0 +1,327 @@
+package combat
+
+import (
+	"context"
+	"testing"
+)
+
+func TestBasicEnemyAI_BasicAttack(t *testing.T) {
+	ai := NewBasicEnemyAI()
+
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsPlayer: false, Team: 1, HP: 30, MaxHP: 30, IsAlive: true},
+		},
+	}
+
+	self := combat.Participants[1]
+
+	action := ai.Decide(context.Background(), combat, self)
+
+	if action == nil {
+		t.Fatal("Expected action, got nil")
+	}
+	if action.ActionID != "attack" {
+		t.Errorf("Expected action 'attack', got '%s'", action.ActionID)
+	}
+	if action.TargetID != 1 {
+		t.Errorf("Expected target ID 1 (player), got %d", action.TargetID)
+	}
+}
+
+func TestBasicEnemyAI_FleeWhenLowHP(t *testing.T) {
+	ai := &BasicEnemyAI{
+		FleeThreshold: 0.25,
+		HealThreshold: 0.30,
+		Aggression:    0.5,
+		Abilities:     []string{},
+	}
+
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsPlayer: false, Team: 1, HP: 5, MaxHP: 30, Dexterity: 80, IsAlive: true}, // 16% HP
+		},
+	}
+
+	self := combat.Participants[1]
+
+	// With high DEX, flee chance should be 80%
+	// Run multiple times to check flee behavior
+	fleeCount := 0
+	runs := 100
+	for i := 0; i < runs; i++ {
+		action := ai.Decide(context.Background(), combat, self)
+		if action.ActionID == "flee" {
+			fleeCount++
+		}
+	}
+
+	// Should flee approximately 80% of the time given high DEX
+	if fleeCount < 50 { // Allow some variance
+		t.Errorf("Expected flee behavior at least 50%% of time (got %d%%)", fleeCount)
+	}
+}
+
+func TestBasicEnemyAI_HealAbility(t *testing.T) {
+	// First, register a heal ability for testing
+	SkillActions["enemy_heal"] = &ActionDefinition{
+		ID:         "enemy_heal",
+		Name:       "Enemy Heal",
+		Type:       ActionInstant,
+		TickCost:   1,
+		BaseHeal:   10,
+		Cooldown:   0,
+	}
+	defer delete(SkillActions, "enemy_heal")
+
+	ai := &BasicEnemyAI{
+		FleeThreshold: 0.25,
+		HealThreshold: 0.30,
+		Aggression:    0.0, // No aggression - should still try to heal
+		Abilities:     []string{"enemy_heal"},
+	}
+
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsPlayer: false, Team: 1, HP: 5, MaxHP: 30, Dexterity: 0, IsAlive: true}, // Low HP, no DEX for flee
+		},
+	}
+
+	self := combat.Participants[1]
+
+	action := ai.Decide(context.Background(), combat, self)
+
+	if action == nil {
+		t.Fatal("Expected action, got nil")
+	}
+	if action.ActionID != "enemy_heal" {
+		t.Errorf("Expected 'enemy_heal' action, got '%s'", action.ActionID)
+	}
+	if action.Reason != "low_hp_heal" {
+		t.Errorf("Expected reason 'low_hp_heal', got '%s'", action.Reason)
+	}
+}
+
+func TestBasicEnemyAI_OffensiveAbility(t *testing.T) {
+	// Register test ability
+	SkillActions["crush"] = &ActionDefinition{
+		ID:         "crush",
+		Name:       "Crush",
+		Type:       ActionInstant,
+		TickCost:   2,
+		BaseDamage: 12,
+		Cooldown:   2,
+	}
+	defer delete(SkillActions, "crush")
+
+	ai := &BasicEnemyAI{
+		FleeThreshold: 0.25,
+		Aggression:    1.0, // Always use abilities
+		Abilities:     []string{"crush"},
+	}
+
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsPlayer: false, Team: 1, HP: 30, MaxHP: 30, IsAlive: true},
+		},
+	}
+
+	self := combat.Participants[1]
+
+	action := ai.Decide(context.Background(), combat, self)
+
+	if action == nil {
+		t.Fatal("Expected action, got nil")
+	}
+	if action.ActionID != "crush" {
+		t.Errorf("Expected 'crush' action, got '%s'", action.ActionID)
+	}
+	if action.Reason != "ability_offensive" {
+		t.Errorf("Expected reason 'ability_offensive', got '%s'", action.Reason)
+	}
+}
+
+func TestBasicEnemyAI_FocusWeakestTarget(t *testing.T) {
+	ai := NewBasicEnemyAI()
+
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player1", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Player2", IsPlayer: true, Team: 0, HP: 10, MaxHP: 50, IsAlive: true}, // Weak target
+			{ID: 3, Name: "Enemy", IsPlayer: false, Team: 1, HP: 30, MaxHP: 30, IsAlive: true},
+		},
+	}
+
+	self := combat.Participants[2]
+
+	// Run multiple times - should always target Player2 (lowest HP %)
+	for i := 0; i < 10; i++ {
+		action := ai.Decide(context.Background(), combat, self)
+		if action.TargetID != 2 {
+			t.Errorf("Expected target ID 2 (weakest), got %d", action.TargetID)
+		}
+	}
+}
+
+func TestEnemyRegistry(t *testing.T) {
+	// Test that all enemies are defined
+	expectedEnemies := []string{"scrap_rat", "junk_dog", "ooze_spawn", "old_scrap"}
+
+	for _, id := range expectedEnemies {
+		def, exists := GetEnemyDefinition(id)
+		if !exists {
+			t.Errorf("Expected enemy '%s' in registry", id)
+			continue
+		}
+		if def.Name == "" {
+			t.Errorf("Enemy '%s' has no name", id)
+		}
+		if def.HP <= 0 {
+			t.Errorf("Enemy '%s' has invalid HP: %d", id, def.HP)
+		}
+		if def.AI == nil {
+			t.Errorf("Enemy '%s' has no AI", id)
+		}
+	}
+}
+
+func TestCreateParticipantFromEnemy(t *testing.T) {
+	participant := CreateParticipantFromEnemy("scrap_rat", 1)
+
+	if participant == nil {
+		t.Fatal("Expected participant, got nil")
+	}
+
+	def, _ := GetEnemyDefinition("scrap_rat")
+
+	if participant.Name != def.Name {
+		t.Errorf("Expected name '%s', got '%s'", def.Name, participant.Name)
+	}
+	if participant.HP != def.HP {
+		t.Errorf("Expected HP %d, got %d", def.HP, participant.HP)
+	}
+	if participant.MaxHP != def.HP {
+		t.Errorf("Expected MaxHP %d, got %d", def.HP, participant.MaxHP)
+	}
+	if participant.Team != 1 {
+		t.Errorf("Expected team 1 (enemy), got %d", participant.Team)
+	}
+	if participant.IsPlayer {
+		t.Error("Enemy should not be marked as player")
+	}
+	if !participant.IsNPC {
+		t.Error("Enemy should be marked as NPC")
+	}
+}
+
+func TestCreateParticipantFromEnemy_InvalidID(t *testing.T) {
+	participant := CreateParticipantFromEnemy("nonexistent_enemy", 1)
+
+	if participant != nil {
+		t.Error("Expected nil for invalid enemy ID, got participant")
+	}
+}
+
+func TestGetAIAction(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Scrap Rat", IsPlayer: false, Team: 1, HP: 15, MaxHP: 15, IsAlive: true},
+		},
+	}
+
+	self := combat.Participants[1]
+
+	action := GetAIAction("scrap_rat", combat, self)
+
+	if action == nil {
+		t.Fatal("Expected action, got nil")
+	}
+	if action.ActionID != "attack" {
+		t.Errorf("Expected 'attack' for scrap_rat, got '%s'", action.ActionID)
+	}
+}
+
+func TestGetAIAction_InvalidEnemy(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Unknown", IsPlayer: false, Team: 1, HP: 10, MaxHP: 10, IsAlive: true},
+		},
+	}
+
+	self := combat.Participants[1]
+
+	// Should fall back to basic AI
+	action := GetAIAction("invalid_enemy", combat, self)
+
+	if action == nil {
+		t.Fatal("Expected fallback action, got nil")
+	}
+	if action.ActionID != "attack" {
+		t.Errorf("Expected fallback 'attack', got '%s'", action.ActionID)
+	}
+}
+
+func TestAIAction_Priority(t *testing.T) {
+	// Flee should have highest priority (100)
+	// Heal should have high priority (90)
+	// Ability should have medium priority (70)
+	// Basic attack should have lowest priority (50)
+
+	ai := NewBasicEnemyAI()
+
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsPlayer: false, Team: 1, HP: 30, MaxHP: 30, IsAlive: true},
+		},
+	}
+
+	self := combat.Participants[1]
+	action := ai.Decide(context.Background(), combat, self)
+
+	if action.Priority < 50 {
+		t.Errorf("Basic attack should have priority >= 50, got %d", action.Priority)
+	}
+}
+
+func TestEnemyDefinition_SpecialAbilities(t *testing.T) {
+	// Junk Dog should have bite ability
+	junkDog, exists := GetEnemyDefinition("junk_dog")
+	if !exists {
+		t.Fatal("junk_dog not found in registry")
+	}
+	if len(junkDog.Abilities) != 1 || junkDog.Abilities[0] != "bite" {
+		t.Errorf("junk_dog should have 'bite' ability, got %v", junkDog.Abilities)
+	}
+
+	// Old Scrap should have crush and scavenge
+	oldScrap, exists := GetEnemyDefinition("old_scrap")
+	if !exists {
+		t.Fatal("old_scrap not found in registry")
+	}
+	if len(oldScrap.Abilities) != 2 {
+		t.Errorf("old_scrap should have 2 abilities, got %d", len(oldScrap.Abilities))
+	}
+}

--- a/herbst/combat/examine.go
+++ b/herbst/combat/examine.go
@@ -1,0 +1,174 @@
+package combat
+
+import (
+	"math/rand"
+)
+
+// HiddenDetailMode defines how a hidden detail is revealed
+type HiddenDetailMode string
+
+const (
+	// ModeAutomatic reveals the detail when examine skill >= min_examine_level
+	ModeAutomatic HiddenDetailMode = "automatic"
+	// ModeCheck requires a roll against DC (d20 + stat bonus vs DC)
+	ModeCheck HiddenDetailMode = "check"
+)
+
+// HiddenDetail represents a hidden detail on an item or NPC
+type HiddenDetail struct {
+	Text            string          `json:"text"`
+	MinExamineLevel int             `json:"min_examine_level,omitempty"`
+	Mode            HiddenDetailMode `json:"mode"`
+	DC              int             `json:"dc,omitempty"`   // Difficulty class for check mode
+	Stat            string          `json:"stat,omitempty"` // INT or WIS for check mode
+}
+
+// HiddenDetailResult represents the result of revealing a hidden detail
+type HiddenDetailResult struct {
+	Text          string `json:"text"`
+	Revealed      bool   `json:"revealed"`
+	Source        string `json:"source,omitempty"`        // "skill_threshold" or "check_passed"
+	Roll          int    `json:"roll,omitempty"`          // The d20 roll (for check mode)
+	DC            int    `json:"dc,omitempty"`            // The DC (for check mode)
+	RequiredLevel int    `json:"required_level,omitempty"` // Required level (if not revealed)
+}
+
+// ExamineResult represents the complete result of an examine action
+type ExamineResult struct {
+	VisibleDescription string              `json:"visible_description"`
+	HiddenDetails      []HiddenDetailResult `json:"hidden_details"`
+	ExamineXP          int                 `json:"examine_xp"`
+}
+
+// ExamineOptions contains options for the examine action
+type ExamineOptions struct {
+	ExamineSkillLevel int    // Player's examine skill level (0-100)
+	Intelligence      int    // Player's intelligence stat
+	Wisdom            int    // Player's wisdom stat
+}
+
+// Examine performs an examine action on an item with hidden details
+// Returns the examine result with revealed details based on skill and rolls
+func Examine(hiddenDetails []HiddenDetail, opts ExamineOptions) *ExamineResult {
+	result := &ExamineResult{
+		HiddenDetails: make([]HiddenDetailResult, 0, len(hiddenDetails)),
+		ExamineXP:     0,
+	}
+
+	for _, detail := range hiddenDetails {
+		detailResult := HiddenDetailResult{
+			Text: detail.Text,
+		}
+
+		switch detail.Mode {
+		case ModeAutomatic:
+			// Automatic mode: reveal if skill >= threshold
+			if opts.ExamineSkillLevel >= detail.MinExamineLevel {
+				detailResult.Revealed = true
+				detailResult.Source = "skill_threshold"
+				result.ExamineXP++ // XP for successful reveal
+			} else {
+				detailResult.Revealed = false
+				detailResult.RequiredLevel = detail.MinExamineLevel
+			}
+
+		case ModeCheck:
+			// Check mode: roll d20 + stat bonus vs DC
+			roll := rand.Intn(20) + 1 // d20 roll (1-20)
+			detailResult.Roll = roll
+			detailResult.DC = detail.DC
+
+			// Get stat bonus
+			var statBonus int
+			switch detail.Stat {
+			case "INT":
+				// +1 per 2 points above 10, -1 per 2 below 10
+				statBonus = (opts.Intelligence - 10) / 2
+			case "WIS":
+				statBonus = (opts.Wisdom - 10) / 2
+			default:
+				statBonus = (opts.Wisdom-10)/2 + (opts.Intelligence-10)/2
+			}
+
+			totalRoll := roll + statBonus
+			if totalRoll >= detail.DC {
+				detailResult.Revealed = true
+				detailResult.Source = "check_passed"
+				result.ExamineXP++ // XP for successful check
+			} else {
+				detailResult.Revealed = false
+				detailResult.Source = "check_failed"
+			}
+
+		default:
+			// Unknown mode - treat as not revealed
+			detailResult.Revealed = false
+		}
+
+		result.HiddenDetails = append(result.HiddenDetails, detailResult)
+	}
+
+	// Cap XP from examine at 3 (prevents farming)
+	if result.ExamineXP > 3 {
+		result.ExamineXP = 3
+	}
+
+	return result
+}
+
+// ParseHiddenDetails converts raw JSON data to HiddenDetail structs
+// This is useful for loading from database JSON fields
+func ParseHiddenDetails(data []map[string]interface{}) []HiddenDetail {
+	details := make([]HiddenDetail, 0, len(data))
+	for _, d := range data {
+		detail := HiddenDetail{}
+
+		if text, ok := d["text"].(string); ok {
+			detail.Text = text
+		}
+		if minLevel, ok := d["min_examine_level"].(float64); ok {
+			detail.MinExamineLevel = int(minLevel)
+		}
+		if mode, ok := d["mode"].(string); ok {
+			detail.Mode = HiddenDetailMode(mode)
+		}
+		if dc, ok := d["dc"].(float64); ok {
+			detail.DC = int(dc)
+		}
+		if stat, ok := d["stat"].(string); ok {
+			detail.Stat = stat
+		}
+
+		details = append(details, detail)
+	}
+	return details
+}
+
+// FormatExamineOutput creates a human-readable string from an ExamineResult
+func FormatExamineOutput(result *ExamineResult) string {
+	output := ""
+
+	// Show revealed details
+	revealed := false
+	for _, detail := range result.HiddenDetails {
+		if detail.Revealed {
+			if !revealed {
+				output += "\n  You notice:\n"
+				revealed = true
+			}
+			output += "  - " + detail.Text + "\n"
+			if detail.Source == "check_passed" {
+				output += "    [REVEALED via perception check: roll " + string(rune('0'+detail.Roll/10)) + string(rune('0'+detail.Roll%10)) + " vs DC " + string(rune('0'+detail.DC/10)) + string(rune('0'+detail.DC%10)) + "]\n"
+			}
+		}
+	}
+
+	// Show hints for unrevealed automatic details
+	for _, detail := range result.HiddenDetails {
+		if !detail.Revealed && detail.RequiredLevel > 0 {
+			output += "\n  [Hidden detail requires examine level " + string(rune('0'+detail.RequiredLevel/10)) + string(rune('0'+detail.RequiredLevel%10)) + "]\n"
+		}
+	}
+
+	return output
+}

--- a/herbst/combat/examine_test.go
+++ b/herbst/combat/examine_test.go
@@ -1,0 +1,385 @@
+package combat
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestExamine_AutomaticMode_RevealedAtThreshold(t *testing.T) {
+	details := []HiddenDetail{
+		{
+			Text:            "Coins glint at the bottom",
+			MinExamineLevel: 0,
+			Mode:            ModeAutomatic,
+		},
+	}
+
+	opts := ExamineOptions{
+		ExamineSkillLevel: 5,
+		Intelligence:      10,
+		Wisdom:            10,
+	}
+
+	result := Examine(details, opts)
+
+	if len(result.HiddenDetails) != 1 {
+		t.Fatalf("Expected 1 hidden detail, got %d", len(result.HiddenDetails))
+	}
+
+	if !result.HiddenDetails[0].Revealed {
+		t.Error("Expected detail to be revealed at skill level 5 with threshold 0")
+	}
+	if result.HiddenDetails[0].Source != "skill_threshold" {
+		t.Errorf("Expected source 'skill_threshold', got '%s'", result.HiddenDetails[0].Source)
+	}
+	if result.ExamineXP != 1 {
+		t.Errorf("Expected 1 XP for reveal, got %d", result.ExamineXP)
+	}
+}
+
+func TestExamine_AutomaticMode_NotRevealedBelowThreshold(t *testing.T) {
+	details := []HiddenDetail{
+		{
+			Text:            "A hidden compartment behind the statue",
+			MinExamineLevel: 75,
+			Mode:            ModeAutomatic,
+		},
+	}
+
+	opts := ExamineOptions{
+		ExamineSkillLevel: 50, // Below threshold
+		Intelligence:      10,
+		Wisdom:            10,
+	}
+
+	result := Examine(details, opts)
+
+	if result.HiddenDetails[0].Revealed {
+		t.Error("Expected detail NOT to be revealed below threshold")
+	}
+	if result.HiddenDetails[0].RequiredLevel != 75 {
+		t.Errorf("Expected required level 75, got %d", result.HiddenDetails[0].RequiredLevel)
+	}
+	if result.ExamineXP != 0 {
+		t.Errorf("Expected 0 XP without reveal, got %d", result.ExamineXP)
+	}
+}
+
+func TestExamine_AutomaticMode_ExactThreshold(t *testing.T) {
+	details := []HiddenDetail{
+		{
+			Text:            "Faint writing: WISH UPON THE OOZE",
+			MinExamineLevel: 50,
+			Mode:            ModeAutomatic,
+		},
+	}
+
+	opts := ExamineOptions{
+		ExamineSkillLevel: 50, // Exactly at threshold
+		Intelligence:      10,
+		Wisdom:            10,
+	}
+
+	result := Examine(details, opts)
+
+	if !result.HiddenDetails[0].Revealed {
+		t.Error("Expected detail to be revealed at exact threshold")
+	}
+}
+
+func TestExamine_CheckMode_PassWithRoll(t *testing.T) {
+	// Use fixed seed for deterministic testing
+	rand.Seed(42)
+
+	details := []HiddenDetail{
+		{
+			Text: "A crack in the base",
+			Mode: ModeCheck,
+			DC:   10, // Low DC
+			Stat: "INT",
+		},
+	}
+
+	// High INT gives +5 bonus (INT 20: (20-10)/2 = 5)
+	opts := ExamineOptions{
+		ExamineSkillLevel: 0,
+		Intelligence:      20,
+		Wisdom:            10,
+	}
+
+	// Run multiple times to account for randomness
+	successCount := 0
+	for i := 0; i < 100; i++ {
+		result := Examine(details, opts)
+		if result.HiddenDetails[0].Revealed {
+			successCount++
+		}
+	}
+
+	// With INT 20 (+5 bonus) and DC 10, even rolling a 1 gives us 6 (1+5=6)
+	// So we should pass when roll >= 5, which is 80% of the time (16/20 rolls)
+	// With 100 runs, expect ~80 successes
+	if successCount < 60 {
+		t.Errorf("Expected at least 60 successes with high INT, got %d", successCount)
+	}
+}
+
+func TestExamine_CheckMode_FailWithLowRoll(t *testing.T) {
+	// Use fixed seed for deterministic testing
+	rand.Seed(42)
+
+	details := []HiddenDetail{
+		{
+			Text: "A hidden compartment",
+			Mode: ModeCheck,
+			DC:   30, // Very high DC
+			Stat: "INT",
+		},
+	}
+
+	opts := ExamineOptions{
+		ExamineSkillLevel: 0,
+		Intelligence:      10, // No bonus
+		Wisdom:            10,
+	}
+
+	// Run multiple times - should almost always fail
+	successCount := 0
+	for i := 0; i < 100; i++ {
+		result := Examine(details, opts)
+		if result.HiddenDetails[0].Revealed {
+			successCount++
+		}
+	}
+
+	// DC 30 with no bonus requires rolling 30 on a d20, which is impossible
+	// Natural 20 is only 20, so should fail 100% of the time
+	if successCount > 0 {
+		t.Errorf("Expected 0 successes with impossible DC, got %d", successCount)
+	}
+}
+
+func TestExamine_CheckMode_WisdomBonus(t *testing.T) {
+	details := []HiddenDetail{
+		{
+			Text: "A crack in the base",
+			Mode: ModeCheck,
+			DC:   15,
+			Stat: "WIS",
+		},
+	}
+
+	// WIS 18 gives +4 bonus: (18-10)/2 = 4
+	opts := ExamineOptions{
+		ExamineSkillLevel: 0,
+		Intelligence:      10,
+		Wisdom:            18,
+	}
+
+	successCount := 0
+	for i := 0; i < 100; i++ {
+		result := Examine(details, opts)
+		if result.HiddenDetails[0].Revealed {
+			successCount++
+		}
+	}
+
+	// DC 15 with +4 bonus requires roll >= 11 (roll 11-20 = 10/20 = 50%)
+	// With 100 runs, expect ~50 successes
+	if successCount < 35 || successCount > 65 {
+		t.Errorf("Expected ~50 successes with WIS bonus, got %d", successCount)
+	}
+}
+
+func TestExamine_MultipleDetails(t *testing.T) {
+	details := []HiddenDetail{
+		{
+			Text:            "Coins glint at the bottom",
+			MinExamineLevel: 0,
+			Mode:            ModeAutomatic,
+		},
+		{
+			Text:            "A crack in the base",
+			Mode:            ModeCheck,
+			DC:              10,
+			Stat:            "WIS",
+		},
+		{
+			Text:            "A hidden compartment behind the statue",
+			MinExamineLevel: 75,
+			Mode:            ModeAutomatic,
+		},
+	}
+
+	opts := ExamineOptions{
+		ExamineSkillLevel: 50,
+		Intelligence:      14, // +2 bonus
+		Wisdom:            14, // +2 bonus
+	}
+
+	result := Examine(details, opts)
+
+	if len(result.HiddenDetails) != 3 {
+		t.Fatalf("Expected 3 hidden details, got %d", len(result.HiddenDetails))
+	}
+
+	// First detail (automatic, threshold 0) - should be revealed
+	if !result.HiddenDetails[0].Revealed {
+		t.Error("Expected first detail to be revealed")
+	}
+
+	// Second detail (check, DC 10) - check result should be present
+	if result.HiddenDetails[1].Roll < 1 || result.HiddenDetails[1].Roll > 20 {
+		t.Errorf("Expected roll between 1-20, got %d", result.HiddenDetails[1].Roll)
+	}
+	if result.HiddenDetails[1].DC != 10 {
+		t.Errorf("Expected DC 10, got %d", result.HiddenDetails[1].DC)
+	}
+
+	// Third detail (automatic, threshold 75) - should NOT be revealed
+	if result.HiddenDetails[2].Revealed {
+		t.Error("Expected third detail NOT to be revealed")
+	}
+	if result.HiddenDetails[2].RequiredLevel != 75 {
+		t.Errorf("Expected required level 75, got %d", result.HiddenDetails[2].RequiredLevel)
+	}
+
+	// XP should be at least 1 (first detail always revealed)
+	if result.ExamineXP < 1 {
+		t.Errorf("Expected at least 1 XP, got %d", result.ExamineXP)
+	}
+}
+
+func TestExamine_XPCapped(t *testing.T) {
+	// Create many details that would give lots of XP
+	details := make([]HiddenDetail, 10)
+	for i := range details {
+		details[i] = HiddenDetail{
+			Text:            "Detail " + string(rune('0'+i)),
+			MinExamineLevel: 0,
+			Mode:            ModeAutomatic,
+		}
+	}
+
+	opts := ExamineOptions{
+		ExamineSkillLevel: 100,
+		Intelligence:      10,
+		Wisdom:            10,
+	}
+
+	result := Examine(details, opts)
+
+	// XP should be capped at 3
+	if result.ExamineXP > 3 {
+		t.Errorf("Expected XP capped at 3, got %d", result.ExamineXP)
+	}
+}
+
+func TestParseHiddenDetails(t *testing.T) {
+	data := []map[string]interface{}{
+		{
+			"text":              "Coins glint at the bottom",
+			"min_examine_level": float64(0),
+			"mode":              "automatic",
+		},
+		{
+			"text": "A crack in the base",
+			"mode": "check",
+			"dc":   float64(30),
+			"stat": "INT",
+		},
+		{
+			"text":              "A hidden compartment",
+			"min_examine_level": float64(75),
+			"mode":              "automatic",
+		},
+	}
+
+	details := ParseHiddenDetails(data)
+
+	if len(details) != 3 {
+		t.Fatalf("Expected 3 details, got %d", len(details))
+	}
+
+	// First detail
+	if details[0].Text != "Coins glint at the bottom" {
+		t.Errorf("Expected text 'Coins glint at the bottom', got '%s'", details[0].Text)
+	}
+	if details[0].MinExamineLevel != 0 {
+		t.Errorf("Expected min_examine_level 0, got %d", details[0].MinExamineLevel)
+	}
+	if details[0].Mode != ModeAutomatic {
+		t.Errorf("Expected mode 'automatic', got '%s'", details[0].Mode)
+	}
+
+	// Second detail
+	if details[1].Text != "A crack in the base" {
+		t.Errorf("Expected text 'A crack in the base', got '%s'", details[1].Text)
+	}
+	if details[1].Mode != ModeCheck {
+		t.Errorf("Expected mode 'check', got '%s'", details[1].Mode)
+	}
+	if details[1].DC != 30 {
+		t.Errorf("Expected DC 30, got %d", details[1].DC)
+	}
+	if details[1].Stat != "INT" {
+		t.Errorf("Expected stat 'INT', got '%s'", details[1].Stat)
+	}
+
+	// Third detail
+	if details[2].MinExamineLevel != 75 {
+		t.Errorf("Expected min_examine_level 75, got %d", details[2].MinExamineLevel)
+	}
+}
+
+func TestExamine_EmptyDetails(t *testing.T) {
+	details := []HiddenDetail{}
+
+	opts := ExamineOptions{
+		ExamineSkillLevel: 50,
+		Intelligence:      10,
+		Wisdom:            10,
+	}
+
+	result := Examine(details, opts)
+
+	if len(result.HiddenDetails) != 0 {
+		t.Errorf("Expected 0 hidden details, got %d", len(result.HiddenDetails))
+	}
+	if result.ExamineXP != 0 {
+		t.Errorf("Expected 0 XP for empty details, got %d", result.ExamineXP)
+	}
+}
+
+func TestExamine_DefaultStatBonus(t *testing.T) {
+	details := []HiddenDetail{
+		{
+			Text: "Something suspicious",
+			Mode: ModeCheck,
+			DC:   15,
+			// No stat specified - should use default (INT+WIS bonus)
+		},
+	}
+
+	// INT 14 (+2) + WIS 14 (+2) = +4 total bonus
+	opts := ExamineOptions{
+		ExamineSkillLevel: 0,
+		Intelligence:      14,
+		Wisdom:            14,
+	}
+
+	// Run multiple times to check for successful reveals
+	successCount := 0
+	for i := 0; i < 100; i++ {
+		result := Examine(details, opts)
+		if result.HiddenDetails[0].Revealed {
+			successCount++
+		}
+	}
+
+	// DC 15 with +4 bonus requires roll >= 11 (50% chance)
+	// With 100 runs, expect ~50 successes
+	if successCount < 35 || successCount > 65 {
+		t.Errorf("Expected ~50 successes with default stat, got %d", successCount)
+	}
+}

--- a/herbst/combat/initiative.go
+++ b/herbst/combat/initiative.go
@@ -1,0 +1,137 @@
+package combat
+
+import (
+	"math/rand"
+	"sort"
+)
+
+// InitiativeRoll represents an initiative roll result
+type InitiativeRoll struct {
+	Participant *Participant
+	Roll        int // Random 1-20
+	Dexterity   int // DEX stat
+	Total       int // Roll + DEX (used for tie-breaking)
+}
+
+// RollInitiative calculates initiative for a participant
+// Initiative = DEX + random(1,20)
+func RollInitiative(p *Participant) int {
+	roll := rand.Intn(20) + 1 // 1-20
+	p.Initiative = p.Dexterity + roll
+	return p.Initiative
+}
+
+// RollAllInitiative calculates initiative for all participants in a combat
+func RollAllInitiative(participants []*Participant) {
+	for _, p := range participants {
+		RollInitiative(p)
+	}
+}
+
+// SortByInitiative sorts participants by initiative (descending)
+// Ties are broken by DEX, then by random roll
+func SortByInitiative(participants []*Participant) {
+	sort.Slice(participants, func(i, j int) bool {
+		// Higher initiative goes first
+		if participants[i].Initiative != participants[j].Initiative {
+			return participants[i].Initiative > participants[j].Initiative
+		}
+		// Tie-breaker: higher DEX goes first
+		if participants[i].Dexterity != participants[j].Dexterity {
+			return participants[i].Dexterity > participants[j].Dexterity
+		}
+		// Final tie-breaker: random
+		return rand.Intn(2) == 0
+	})
+}
+
+// GetTurnOrder returns the initiative order as a slice of participants
+func (c *Combat) GetTurnOrder() []*Participant {
+	// Get all alive participants
+	alive := c.GetAliveParticipants()
+	
+	// Copy and sort by initiative
+	order := make([]*Participant, len(alive))
+	copy(order, alive)
+	SortByInitiative(order)
+	
+	// Set turn positions
+	for i, p := range order {
+		p.TurnPosition = i + 1
+	}
+	
+	return order
+}
+
+// GetTurnOrderString returns a formatted string of turn order for display
+func (c *Combat) GetTurnOrderString() string {
+	order := c.GetTurnOrder()
+	if len(order) == 0 {
+		return "No combatants"
+	}
+	
+	result := "Turn Order:\n"
+	for i, p := range order {
+		teamLabel := "Ally"
+		if p.Team == 1 {
+			teamLabel = "Enemy"
+		}
+		status := ""
+		if !p.IsAlive {
+			status = " [DEAD]"
+		}
+		result += FormatCombatLog("  %d. %s (%s) - Initiative: %d%s\n",
+			i+1, p.Name, teamLabel, p.Initiative, status)
+	}
+	return result
+}
+
+// GetCurrentActor returns the participant whose turn it is
+// This assumes round-robin turn order based on initiative
+func (c *Combat) GetCurrentActor(turnIndex int) *Participant {
+	order := c.GetTurnOrder()
+	if len(order) == 0 {
+		return nil
+	}
+	// Wrap around for round-robin
+	return order[turnIndex % len(order)]
+}
+
+// GetNextActor returns the next participant in turn order
+func (c *Combat) GetNextActor(currentIndex int) (nextIndex int, actor *Participant) {
+	order := c.GetTurnOrder()
+	if len(order) == 0 {
+		return 0, nil
+	}
+	nextIndex = (currentIndex + 1) % len(order)
+	return nextIndex, order[nextIndex]
+}
+
+// InitiativeRollDetailed returns detailed initiative info for display
+type InitiativeRollDetailed struct {
+	Name        string `json:"name"`
+	IsPlayer    bool   `json:"isPlayer"`
+	Dexterity   int    `json:"dexterity"`
+	Roll        int    `json:"roll"`
+	Total       int    `json:"total"`
+	TurnOrder   int    `json:"turnOrder"`
+}
+
+// GetInitiativeRolls returns detailed initiative information for all participants
+func (c *Combat) GetInitiativeRolls() []InitiativeRollDetailed {
+	order := c.GetTurnOrder()
+	rolls := make([]InitiativeRollDetailed, len(order))
+	
+	for i, p := range order {
+		rolls[i] = InitiativeRollDetailed{
+			Name:      p.Name,
+			IsPlayer:  p.IsPlayer,
+			Dexterity: p.Dexterity,
+			Roll:      p.Initiative - p.Dexterity, // The dice roll portion
+			Total:     p.Initiative,
+			TurnOrder: i + 1,
+		}
+	}
+	
+	return rolls
+}

--- a/herbst/combat/initiative_test.go
+++ b/herbst/combat/initiative_test.go
@@ -1,0 +1,135 @@
+package combat
+
+import (
+	"testing"
+)
+
+func TestRollInitiative(t *testing.T) {
+	p := &Participant{
+		ID:         1,
+		Name:       "Hero",
+		Dexterity:  15,
+	}
+	
+	result := RollInitiative(p)
+	
+	// Initiative should be DEX + roll (1-20)
+	// So result should be between 16 (15+1) and 35 (15+20)
+	if result < 16 || result > 35 {
+		t.Errorf("Initiative %d out of expected range [16, 35]", result)
+	}
+	
+	if p.Initiative != result {
+		t.Errorf("Participant initiative not set correctly, expected %d, got %d", result, p.Initiative)
+	}
+}
+
+func TestSortByInitiative(t *testing.T) {
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", Dexterity: 10, Initiative: 25},
+		{ID: 2, Name: "Goblin", Dexterity: 8, Initiative: 15},
+		{ID: 3, Name: "Mage", Dexterity: 16, Initiative: 30},
+	}
+	
+	SortByInitiative(participants)
+	
+	if participants[0].ID != 3 {
+		t.Errorf("Expected Mage (ID 3) first, got %s (ID %d)", participants[0].Name, participants[0].ID)
+	}
+	if participants[1].ID != 1 {
+		t.Errorf("Expected Hero (ID 1) second, got %s (ID %d)", participants[1].Name, participants[1].ID)
+	}
+	if participants[2].ID != 2 {
+		t.Errorf("Expected Goblin (ID 2) third, got %s (ID %d)", participants[2].Name, participants[2].ID)
+	}
+}
+
+func TestGetTurnOrder(t *testing.T) {
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", Team: 0, IsAlive: true, Initiative: 20},
+		{ID: 2, Name: "Goblin", Team: 1, IsAlive: true, Initiative: 15},
+		{ID: 3, Name: "Orc", Team: 1, IsAlive: true, Initiative: 18},
+	}
+	
+	combat := &Combat{
+		ID:           1,
+		Participants: participants,
+	}
+	
+	order := combat.GetTurnOrder()
+	
+	if len(order) != 3 {
+		t.Errorf("Expected 3 participants in turn order, got %d", len(order))
+	}
+	
+	// Check turn positions are set
+	if order[0].TurnPosition != 1 {
+		t.Errorf("Expected first participant to have position 1, got %d", order[0].TurnPosition)
+	}
+}
+
+func TestGetCurrentActor(t *testing.T) {
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", Team: 0, IsAlive: true, Initiative: 20},
+		{ID: 2, Name: "Goblin", Team: 1, IsAlive: true, Initiative: 15},
+	}
+	
+	combat := &Combat{
+		ID:           1,
+		Participants: participants,
+	}
+	
+	// Get turn order first
+	combat.GetTurnOrder()
+	
+	// Turn index 0 should return first actor
+	actor := combat.GetCurrentActor(0)
+	if actor == nil || actor.ID != 1 {
+		t.Errorf("Expected Hero (ID 1) at turn 0, got %v", actor)
+	}
+	
+	// Turn index 1 should return second actor
+	actor = combat.GetCurrentActor(1)
+	if actor == nil || actor.ID != 2 {
+		t.Errorf("Expected Goblin (ID 2) at turn 1, got %v", actor)
+	}
+	
+	// Turn index 2 should wrap back to first (modular)
+	actor = combat.GetCurrentActor(2)
+	if actor == nil || actor.ID != 1 {
+		t.Errorf("Expected Hero (ID 1) at turn 2 (wrap), got %v", actor)
+	}
+}
+
+func TestGetNextActor(t *testing.T) {
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", Team: 0, IsAlive: true, Initiative: 20},
+		{ID: 2, Name: "Goblin", Team: 1, IsAlive: true, Initiative: 15},
+	}
+	
+	combat := &Combat{
+		ID:           1,
+		Participants: participants,
+	}
+	
+	combat.GetTurnOrder()
+	
+	nextIdx, nextActor := combat.GetNextActor(0)
+	
+	if nextIdx != 1 {
+		t.Errorf("Expected next index 1, got %d", nextIdx)
+	}
+	
+	if nextActor == nil || nextActor.ID != 2 {
+		t.Errorf("Expected Goblin (ID 2) as next actor, got %v", nextActor)
+	}
+	
+	// Test wrap-around
+	nextIdx, nextActor = combat.GetNextActor(1)
+	if nextIdx != 0 {
+		t.Errorf("Expected next index 0 (wrap), got %d", nextIdx)
+	}
+	if nextActor == nil || nextActor.ID != 1 {
+		t.Errorf("Expected Hero (ID 1) as next actor (wrap), got %v", nextActor)
+	}
+}

--- a/herbst/combat/input.go
+++ b/herbst/combat/input.go
@@ -1,0 +1,486 @@
+package combat
+
+import (
+	"sync"
+	"time"
+)
+
+// InputMode defines how the input system works
+type InputMode string
+
+const (
+	// InputModeRealTime requires input within the tick window
+	InputModeRealTime InputMode = "REAL_TIME"
+	// InputModeTurnBased waits for input before advancing
+	InputModeTurnBased InputMode = "TURN_BASED"
+	// InputModeHybrid allows real-time input with auto-actions on timeout
+	InputModeHybrid InputMode = "HYBRID"
+)
+
+// InputConfig holds input system configuration
+type InputConfig struct {
+	// Input window duration (default 1.5s)
+	InputWindow time.Duration
+	
+	// Mode for input handling
+	Mode InputMode
+	
+	// Auto-attack when no input received
+	AutoAttackEnabled bool
+	
+	// Auto-defend when HP below threshold
+	AutoDefendEnabled bool
+	AutoDefendHPTreshold float64 // 0.0-1.0 (percentage)
+	
+	// Allow late input queuing
+	LateInputQueueing bool
+	
+	// Number of talent slots
+	TalentSlots int
+}
+
+// DefaultInputConfig returns the default input configuration
+func DefaultInputConfig() InputConfig {
+	return InputConfig{
+		InputWindow:           TickDuration, // 1.5s
+		Mode:                  InputModeHybrid,
+		AutoAttackEnabled:     true,
+		AutoDefendEnabled:     true,
+		AutoDefendHPTreshold:  0.3, // 30% HP
+		LateInputQueueing:     true,
+		TalentSlots:           4,
+	}
+}
+
+// InputState represents the current input state for a participant
+type InputState struct {
+	mu sync.RWMutex
+	
+	// Participant info
+	ParticipantID int
+	
+	// Whether waiting for input
+	AwaitingInput bool
+	
+	// When input window closes
+	Deadline time.Time
+	
+	// Selected action (if any)
+	SelectedAction *ActionDefinition
+	SelectedTarget *Participant
+	
+	// Input received
+	InputReceived bool
+	
+	// Input time
+	InputTime time.Time
+	
+	// Late input (arrived after deadline)
+	IsLate bool
+}
+
+// NewInputState creates a new input state for a participant
+func NewInputState(participantID int) *InputState {
+	return &InputState{
+		ParticipantID: participantID,
+	}
+}
+
+// StartInputWindow begins an input window
+func (is *InputState) StartInputWindow(duration time.Duration) {
+	is.mu.Lock()
+	defer is.mu.Unlock()
+	
+	is.AwaitingInput = true
+	is.Deadline = time.Now().Add(duration)
+	is.SelectedAction = nil
+	is.SelectedTarget = nil
+	is.InputReceived = false
+	is.IsLate = false
+}
+
+// SubmitInput records an input action
+func (is *InputState) SubmitInput(action *ActionDefinition, target *Participant) (accepted bool, isLate bool) {
+	is.mu.Lock()
+	defer is.mu.Unlock()
+	
+	now := time.Now()
+	isLate = now.After(is.Deadline)
+	
+	if isLate {
+		is.IsLate = true
+		// Still record late input for queueing
+		is.SelectedAction = action
+		is.SelectedTarget = target
+		is.InputReceived = true
+		is.InputTime = now
+		return false, true
+	}
+	
+	is.SelectedAction = action
+	is.SelectedTarget = target
+	is.InputReceived = true
+	is.InputTime = now
+	is.AwaitingInput = false
+	
+	return true, false
+}
+
+// HasInput returns true if input was received
+func (is *InputState) HasInput() bool {
+	is.mu.RLock()
+	defer is.mu.RUnlock()
+	return is.InputReceived
+}
+
+// IsLateInput returns true if the input was late
+func (is *InputState) WasLate() bool {
+	is.mu.RLock()
+	defer is.mu.RUnlock()
+	return is.IsLate
+}
+
+// TimeRemaining returns time left in the input window
+func (is *InputState) TimeRemaining() time.Duration {
+	is.mu.RLock()
+	defer is.mu.RUnlock()
+	
+	remaining := time.Until(is.Deadline)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+// Clear resets the input state
+func (is *InputState) Clear() {
+	is.mu.Lock()
+	defer is.mu.Unlock()
+	
+	is.AwaitingInput = false
+	is.SelectedAction = nil
+	is.SelectedTarget = nil
+	is.InputReceived = false
+	is.IsLate = false
+}
+
+// InputManager handles input collection for all combat participants
+type InputManager struct {
+	mu sync.RWMutex
+	
+	// Configuration
+	config InputConfig
+	
+	// Input states by participant ID
+	states map[int]*InputState
+	
+	// Talent bindings by participant ID (slot -> action ID)
+	talentBindings map[int]map[int]string // participantID -> {slot: actionID}
+	
+	// Callback when input received
+	onInput func(participantID int, action *ActionDefinition, target *Participant)
+	
+	// Callback when input times out
+	onTimeout func(participantID int)
+	
+	// Callback for auto-action
+	onAutoAction func(participantID int, action *ActionDefinition)
+}
+
+// NewInputManager creates a new input manager
+func NewInputManager(config InputConfig) *InputManager {
+	return &InputManager{
+		config:         config,
+		states:         make(map[int]*InputState),
+		talentBindings: make(map[int]map[int]string),
+	}
+}
+
+// SetOnInput sets the input received callback
+func (im *InputManager) SetOnInput(callback func(int, *ActionDefinition, *Participant)) {
+	im.mu.Lock()
+	defer im.mu.Unlock()
+	im.onInput = callback
+}
+
+// SetOnTimeout sets the timeout callback
+func (im *InputManager) SetOnTimeout(callback func(int)) {
+	im.mu.Lock()
+	defer im.mu.Unlock()
+	im.onTimeout = callback
+}
+
+// SetOnAutoAction sets the auto-action callback
+func (im *InputManager) SetOnAutoAction(callback func(int, *ActionDefinition)) {
+	im.mu.Lock()
+	defer im.mu.Unlock()
+	im.onAutoAction = callback
+}
+
+// RegisterParticipant adds a participant to the input manager
+func (im *InputManager) RegisterParticipant(participant *Participant) {
+	im.mu.Lock()
+	defer im.mu.Unlock()
+	
+	im.states[participant.ID] = NewInputState(participant.ID)
+	
+	// Set default talent bindings (slots 1-4)
+	im.talentBindings[participant.ID] = map[int]string{
+		1: "attack",
+		2: "defend",
+		3: "item",
+		4: "wait",
+	}
+}
+
+// UnregisterParticipant removes a participant from the input manager
+func (im *InputManager) UnregisterParticipant(participantID int) {
+	im.mu.Lock()
+	defer im.mu.Unlock()
+	
+	delete(im.states, participantID)
+	delete(im.talentBindings, participantID)
+}
+
+// StartInputWindow starts an input window for a participant
+func (im *InputManager) StartInputWindow(participantID int) {
+	im.mu.RLock()
+	state, exists := im.states[participantID]
+	im.mu.RUnlock()
+	
+	if !exists {
+		return
+	}
+	
+	state.StartInputWindow(im.config.InputWindow)
+}
+
+// StartAllInputWindows starts input windows for all participants
+func (im *InputManager) StartAllInputWindows(participants []*Participant) {
+	for _, p := range participants {
+		if p.IsAlive && p.CanAct() {
+			im.StartInputWindow(p.ID)
+		}
+	}
+}
+
+// HandleKeyInput processes a key input (1-4 for talents)
+func (im *InputManager) HandleKeyInput(participantID int, key int, target *Participant) bool {
+	im.mu.RLock()
+	state, exists := im.states[participantID]
+	bindings := im.talentBindings[participantID]
+	im.mu.RUnlock()
+	
+	if !exists {
+		return false
+	}
+	
+	// Get action for key
+	actionID, hasBinding := bindings[key]
+	if !hasBinding {
+		return false
+	}
+	
+	action, found := GetActionDefinition(actionID)
+	if !found {
+		return false
+	}
+	
+	// Submit input
+	accepted, isLate := state.SubmitInput(action, target)
+	
+	if isLate {
+		// Late input - queue for next tick if enabled
+		if im.config.LateInputQueueing {
+			// The state already stores the late input
+			return true
+		}
+		return false
+	}
+	
+	// Fire callback
+	if accepted && im.onInput != nil {
+		im.onInput(participantID, action, target)
+	}
+	
+	return accepted
+}
+
+// HandleActionInput processes a direct action input
+func (im *InputManager) HandleActionInput(participantID int, actionID string, target *Participant) bool {
+	im.mu.RLock()
+	state, exists := im.states[participantID]
+	im.mu.RUnlock()
+	
+	if !exists {
+		return false
+	}
+	
+	action, found := GetActionDefinition(actionID)
+	if !found {
+		return false
+	}
+	
+	accepted, isLate := state.SubmitInput(action, target)
+	
+	if isLate {
+		return im.config.LateInputQueueing
+	}
+	
+	if accepted && im.onInput != nil {
+		im.onInput(participantID, action, target)
+	}
+	
+	return accepted
+}
+
+// CheckTimeout checks for timed-out input windows and applies auto-actions
+func (im *InputManager) CheckTimeout(participantID int, combat *Combat) *ActionDefinition {
+	im.mu.RLock()
+	state, exists := im.states[participantID]
+	im.mu.RUnlock()
+	
+	if !exists {
+		return nil
+	}
+	
+	// Check if still awaiting input
+	if !state.AwaitingInput {
+		return nil
+	}
+	
+	// Check if time has expired
+	if time.Now().Before(state.Deadline) {
+		return nil
+	}
+	
+	// Timeout - apply auto-action
+	var autoAction *ActionDefinition
+	
+	// Get participant
+	participant := combat.GetParticipantByID(participantID)
+	if participant == nil {
+		return nil
+	}
+	
+	// Decide auto-action
+	if im.config.AutoDefendEnabled && participant.HP < int(float64(participant.MaxHP)*im.config.AutoDefendHPTreshold) {
+		// Low HP - auto-defend
+		autoAction, _ = GetActionDefinition("defend")
+	} else if im.config.AutoAttackEnabled {
+		// Default - auto-attack
+		autoAction, _ = GetActionDefinition("attack")
+	}
+	
+	// Fire timeout callback
+	if im.onTimeout != nil {
+		im.onTimeout(participantID)
+	}
+	
+	// Fire auto-action callback
+	if autoAction != nil && im.onAutoAction != nil {
+		im.onAutoAction(participantID, autoAction)
+	}
+	
+	// Clear input state
+	state.Clear()
+	
+	return autoAction
+}
+
+// GetInputState returns the input state for a participant
+func (im *InputManager) GetInputState(participantID int) *InputState {
+	im.mu.RLock()
+	defer im.mu.RUnlock()
+	return im.states[participantID]
+}
+
+// SetTalentBinding binds an action to a talent slot
+func (im *InputManager) SetTalentBinding(participantID int, slot int, actionID string) bool {
+	// Validate slot
+	if slot < 1 || slot > im.config.TalentSlots {
+		return false
+	}
+	
+	// Validate action exists
+	if _, found := GetActionDefinition(actionID); !found {
+		return false
+	}
+	
+	im.mu.Lock()
+	defer im.mu.Unlock()
+	
+	if im.talentBindings[participantID] == nil {
+		im.talentBindings[participantID] = make(map[int]string)
+	}
+	
+	im.talentBindings[participantID][slot] = actionID
+	return true
+}
+
+// GetTalentBindings returns all talent bindings for a participant
+func (im *InputManager) GetTalentBindings(participantID int) map[int]string {
+	im.mu.RLock()
+	defer im.mu.RUnlock()
+	
+	bindings := im.talentBindings[participantID]
+	if bindings == nil {
+		return map[int]string{}
+	}
+	
+	// Return a copy
+	result := make(map[int]string)
+	for k, v := range bindings {
+		result[k] = v
+	}
+	return result
+}
+
+// GetLateInputs returns all late inputs that should be queued for next tick
+func (im *InputManager) GetLateInputs() map[int]*InputState {
+	im.mu.RLock()
+	defer im.mu.RUnlock()
+	
+	result := make(map[int]*InputState)
+	for id, state := range im.states {
+		if state.IsLate {
+			result[id] = state
+		}
+	}
+	return result
+}
+
+// ClearLateInputs clears all late inputs after queuing
+func (im *InputManager) ClearLateInputs() {
+	im.mu.Lock()
+	defer im.mu.Unlock()
+	
+	for _, state := range im.states {
+		if state.IsLate {
+			state.Clear()
+		}
+	}
+}
+
+// GetTimeRemaining returns formatted time remaining for input
+func (im *InputManager) GetTimeRemaining(participantID int) string {
+	state := im.GetInputState(participantID)
+	if state == nil {
+		return "0.0"
+	}
+	
+	remaining := state.TimeRemaining().Seconds()
+	if remaining < 0 {
+		return "0.0"
+	}
+	return FormatCombatLog("%.1f", remaining)
+}
+
+// IsAwaitingInput returns true if waiting for participant input
+func (im *InputManager) IsAwaitingInput(participantID int) bool {
+	state := im.GetInputState(participantID)
+	if state == nil {
+		return false
+	}
+	return state.AwaitingInput
+}

--- a/herbst/combat/input_test.go
+++ b/herbst/combat/input_test.go
@@ -1,0 +1,373 @@
+package combat
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewInputState(t *testing.T) {
+	is := NewInputState(1)
+	
+	if is.ParticipantID != 1 {
+		t.Errorf("Expected participant ID 1, got %d", is.ParticipantID)
+	}
+	
+	if is.AwaitingInput {
+		t.Error("Should not be awaiting input initially")
+	}
+}
+
+func TestInputState_StartInputWindow(t *testing.T) {
+	is := NewInputState(1)
+	
+	is.StartInputWindow(TickDuration)
+	
+	if !is.AwaitingInput {
+		t.Error("Should be awaiting input after start")
+	}
+	
+	if is.Deadline.IsZero() {
+		t.Error("Deadline should be set")
+	}
+	
+	// Deadline should be about 1.5s in the future
+	expected := time.Now().Add(TickDuration)
+	diff := is.Deadline.Sub(expected)
+	if diff < -100*time.Millisecond || diff > 100*time.Millisecond {
+		t.Errorf("Deadline should be ~1.5s from now, diff: %v", diff)
+	}
+}
+
+func TestInputState_SubmitInput(t *testing.T) {
+	is := NewInputState(1)
+	is.StartInputWindow(TickDuration)
+	
+	action := BasicActions["attack"]
+	target := &Participant{ID: 2, Name: "Goblin"}
+	
+	accepted, isLate := is.SubmitInput(action, target)
+	
+	if !accepted {
+		t.Error("Input should be accepted")
+	}
+	
+	if isLate {
+		t.Error("Input should not be late")
+	}
+	
+	if !is.InputReceived {
+		t.Error("Input should be marked as received")
+	}
+	
+	if is.SelectedAction != action {
+		t.Error("Selected action should be stored")
+	}
+	
+	if is.SelectedTarget != target {
+		t.Error("Selected target should be stored")
+	}
+}
+
+func TestInputState_SubmitInput_Late(t *testing.T) {
+	is := NewInputState(1)
+	
+	// Set deadline in the past
+	is.StartInputWindow(time.Microsecond)
+	time.Sleep(2 * time.Millisecond) // Ensure timeout
+	
+	action := BasicActions["attack"]
+	target := &Participant{ID: 2, Name: "Goblin"}
+	
+	accepted, isLate := is.SubmitInput(action, target)
+	
+	if accepted {
+		t.Error("Late input should not be accepted")
+	}
+	
+	if !isLate {
+		t.Error("Input should be marked as late")
+	}
+	
+	if !is.InputReceived {
+		t.Error("Late input should still be recorded")
+	}
+}
+
+func TestInputState_TimeRemaining(t *testing.T) {
+	is := NewInputState(1)
+	is.StartInputWindow(TickDuration)
+	
+	remaining := is.TimeRemaining()
+	
+	if remaining <= 0 {
+		t.Error("Should have time remaining")
+	}
+	
+	if remaining > TickDuration {
+		t.Errorf("Remaining time should not exceed input window")
+	}
+}
+
+func TestInputState_Clear(t *testing.T) {
+	is := NewInputState(1)
+	is.StartInputWindow(TickDuration)
+	is.SubmitInput(BasicActions["attack"], &Participant{ID: 2})
+	
+	is.Clear()
+	
+	if is.AwaitingInput {
+		t.Error("Should not be awaiting after clear")
+	}
+	
+	if is.InputReceived {
+		t.Error("Input received should be cleared")
+	}
+	
+	if is.SelectedAction != nil {
+		t.Error("Selected action should be cleared")
+	}
+}
+
+func TestNewInputManager(t *testing.T) {
+	config := DefaultInputConfig()
+	im := NewInputManager(config)
+	
+	if im.config.InputWindow != TickDuration {
+		t.Errorf("Expected input window %v, got %v", TickDuration, im.config.InputWindow)
+	}
+	
+	if im.config.AutoAttackEnabled != true {
+		t.Error("Auto-attack should be enabled by default")
+	}
+}
+
+func TestInputManager_RegisterParticipant(t *testing.T) {
+	im := NewInputManager(DefaultInputConfig())
+	
+	p := &Participant{ID: 1, Name: "Hero"}
+	im.RegisterParticipant(p)
+	
+	state := im.GetInputState(1)
+	if state == nil {
+		t.Error("State should exist for registered participant")
+	}
+	
+	bindings := im.GetTalentBindings(1)
+	if len(bindings) != 4 {
+		t.Errorf("Expected 4 default bindings, got %d", len(bindings))
+	}
+	
+	// Check default bindings
+	if bindings[1] != "attack" {
+		t.Errorf("Slot 1 should be attack, got %s", bindings[1])
+	}
+}
+
+func TestInputManager_HandleKeyInput(t *testing.T) {
+	im := NewInputManager(DefaultInputConfig())
+	
+	p := &Participant{ID: 1, Name: "Hero"}
+	target := &Participant{ID: 2, Name: "Goblin"}
+	
+	im.RegisterParticipant(p)
+	im.StartInputWindow(1)
+	
+	inputReceived := false
+	im.SetOnInput(func(participantID int, action *ActionDefinition, target *Participant) {
+		inputReceived = true
+	})
+	
+	accepted := im.HandleKeyInput(1, 1, target) // Slot 1 = attack
+	
+	if !accepted {
+		t.Error("Key input should be accepted")
+	}
+	
+	if !inputReceived {
+		t.Error("Callback should have fired")
+	}
+}
+
+func TestInputManager_HandleActionInput(t *testing.T) {
+	im := NewInputManager(DefaultInputConfig())
+	
+	p := &Participant{ID: 1, Name: "Hero"}
+	target := &Participant{ID: 2, Name: "Goblin"}
+	
+	im.RegisterParticipant(p)
+	im.StartInputWindow(1)
+	
+	accepted := im.HandleActionInput(1, "defend", target)
+	
+	if !accepted {
+		t.Error("Action input should be accepted")
+	}
+	
+	state := im.GetInputState(1)
+	if state.SelectedAction.ID != "defend" {
+		t.Errorf("Expected defend action, got %s", state.SelectedAction.ID)
+	}
+}
+
+func TestInputManager_SetTalentBinding(t *testing.T) {
+	im := NewInputManager(DefaultInputConfig())
+	
+	p := &Participant{ID: 1, Name: "Hero"}
+	im.RegisterParticipant(p)
+	
+	// Set custom binding
+	success := im.SetTalentBinding(1, 1, "slash")
+	if !success {
+		t.Error("Setting binding should succeed")
+	}
+	
+	bindings := im.GetTalentBindings(1)
+	if bindings[1] != "slash" {
+		t.Errorf("Slot 1 should be slash, got %s", bindings[1])
+	}
+	
+	// Invalid slot
+	success = im.SetTalentBinding(1, 5, "slash")
+	if success {
+		t.Error("Setting invalid slot should fail")
+	}
+	
+	// Invalid action
+	success = im.SetTalentBinding(1, 1, "nonexistent")
+	if success {
+		t.Error("Setting invalid action should fail")
+	}
+}
+
+func TestInputManager_CheckTimeout(t *testing.T) {
+	im := NewInputManager(DefaultInputConfig())
+	
+	p := &Participant{ID: 1, Name: "Hero", HP: 100, MaxHP: 100}
+	combat := &Combat{
+		Participants: []*Participant{p},
+	}
+	
+	im.RegisterParticipant(p)
+	
+	// Manually set up input state with short deadline
+	state := im.GetInputState(1)
+	state.StartInputWindow(time.Millisecond)
+	
+	time.Sleep(5 * time.Millisecond) // Wait for timeout
+	
+	autoAction := im.CheckTimeout(1, combat)
+	
+	if autoAction == nil {
+		t.Error("Should return auto-action on timeout")
+	}
+	
+	// Should be attack (healthy player)
+	if autoAction.ID != "attack" {
+		t.Errorf("Expected attack, got %s", autoAction.ID)
+	}
+}
+
+func TestInputManager_CheckTimeout_LowHP(t *testing.T) {
+	im := NewInputManager(DefaultInputConfig())
+	
+	// Low HP player (20% of max)
+	p := &Participant{ID: 1, Name: "Hero", HP: 20, MaxHP: 100}
+	combat := &Combat{
+		Participants: []*Participant{p},
+	}
+	
+	im.RegisterParticipant(p)
+	
+	// Manually set up input state with short deadline
+	state := im.GetInputState(1)
+	state.StartInputWindow(time.Millisecond)
+	
+	time.Sleep(5 * time.Millisecond) // Wait for timeout
+	
+	autoAction := im.CheckTimeout(1, combat)
+	
+	if autoAction == nil {
+		t.Error("Should return auto-action on timeout")
+	}
+	
+	// Should be defend (low HP)
+	if autoAction.ID != "defend" {
+		t.Errorf("Expected defend for low HP, got %s", autoAction.ID)
+	}
+}
+
+func TestInputManager_GetLateInputs(t *testing.T) {
+	im := NewInputManager(DefaultInputConfig())
+	
+	p := &Participant{ID: 1, Name: "Hero"}
+	im.RegisterParticipant(p)
+	
+	// Set up late input - use the InputState directly
+	state := im.GetInputState(1)
+	state.StartInputWindow(time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
+	
+	action, _ := GetActionDefinition("attack")
+	state.SubmitInput(action, nil)
+	
+	lateInputs := im.GetLateInputs()
+	
+	if len(lateInputs) != 1 {
+		t.Errorf("Expected 1 late input, got %d", len(lateInputs))
+	}
+	
+	if !lateInputs[1].IsLate {
+		t.Error("Input should be marked as late")
+	}
+	
+	// Clear and check
+	im.ClearLateInputs()
+	lateInputs = im.GetLateInputs()
+	
+	if len(lateInputs) != 0 {
+		t.Errorf("Expected 0 late inputs after clear, got %d", len(lateInputs))
+	}
+}
+
+func TestInputManager_GetTimeRemaining(t *testing.T) {
+	im := NewInputManager(DefaultInputConfig())
+	
+	p := &Participant{ID: 1, Name: "Hero"}
+	im.RegisterParticipant(p)
+	im.StartInputWindow(1)
+	
+	timeStr := im.GetTimeRemaining(1)
+	
+	// Should be a number string
+	if timeStr == "" || timeStr == "0.0" {
+		t.Errorf("Time remaining should not be zero, got %s", timeStr)
+	}
+}
+
+func TestDefaultInputConfig(t *testing.T) {
+	config := DefaultInputConfig()
+	
+	if config.InputWindow != TickDuration {
+		t.Errorf("Expected input window %v, got %v", TickDuration, config.InputWindow)
+	}
+	
+	if !config.AutoAttackEnabled {
+		t.Error("Auto-attack should be enabled")
+	}
+	
+	if !config.AutoDefendEnabled {
+		t.Error("Auto-defend should be enabled")
+	}
+	
+	if config.AutoDefendHPTreshold != 0.3 {
+		t.Errorf("Expected HP threshold 0.3, got %f", config.AutoDefendHPTreshold)
+	}
+	
+	if !config.LateInputQueueing {
+		t.Error("Late input queueing should be enabled")
+	}
+	
+	if config.TalentSlots != 4 {
+		t.Errorf("Expected 4 talent slots, got %d", config.TalentSlots)
+	}
+}

--- a/herbst/combat/interrupt.go
+++ b/herbst/combat/interrupt.go
@@ -1,0 +1,299 @@
+package combat
+
+import (
+	"fmt"
+	"log"
+)
+
+// InterruptType defines the type of interrupt
+type InterruptType string
+
+const (
+	InterruptParry      InterruptType = "PARRY"
+	InterruptShieldBash InterruptType = "SHIELD_BASH"
+	InterruptStun       InterruptType = "STUN"
+)
+
+// InterruptResult represents the result of an interrupt
+type InterruptResult struct {
+	Success        bool          `json:"success"`
+	Type           InterruptType `json:"type"`
+	AttackerID     int           `json:"attackerId"`
+	DefenderID     int           `json:"defenderId"`
+	ActionCancelled string       `json:"actionCancelled"`
+	CounterDamage   int          `json:"counterDamage"`
+	StunDuration    int          `json:"stunDuration"` // Ticks
+	Message         string       `json:"message"`
+}
+
+// ParryAttempt attempts to parry an incoming attack
+// Returns nil if parry is not possible (wrong timing, no attack)
+func ParryAttempt(combat *Combat, defender *Participant, attackerAction *QueuedAction) *InterruptResult {
+	// Parry only works against INSTANT attacks on the same tick
+	attacker := attackerAction.Source
+	if attacker == nil {
+		return nil
+	}
+
+	// Get parry action definition
+	parryDef, exists := GetActionDefinition("parry")
+	if !exists {
+		log.Println("[Parry] Parry action not defined")
+		return nil
+	}
+
+	// Check if defender can use parry (has stamina)
+	if defender.Stamina < parryDef.StaminaCost {
+		return &InterruptResult{
+			Success: false,
+			Message: fmt.Sprintf("%s doesn't have enough stamina to parry!", defender.Name),
+		}
+	}
+
+	// Parry succeeds - cancel the attack
+	result := &InterruptResult{
+		Success:         true,
+		Type:            InterruptParry,
+		AttackerID:      attacker.ID,
+		DefenderID:      defender.ID,
+		ActionCancelled: attackerAction.Action.ID,
+		CounterDamage:   parryDef.BaseDamage,
+		Message:         fmt.Sprintf("%s parries %s's attack!", defender.Name, attacker.Name),
+	}
+
+	// Deduct stamina
+	defender.Stamina -= parryDef.StaminaCost
+
+	// Apply cooldown
+	// (Handled by action queue system)
+
+	return result
+}
+
+// ShieldBashAttempt attempts to interrupt a channeling enemy
+func ShieldBashAttempt(combat *Combat, attacker *Participant, target *Participant) *InterruptResult {
+	// Get shield bash action definition
+	bashDef, exists := GetActionDefinition("shield_bash")
+	if !exists {
+		log.Println("[ShieldBash] Shield bash action not defined")
+		return nil
+	}
+
+	// Check if attacker has enough stamina
+	if attacker.Stamina < bashDef.StaminaCost {
+		return &InterruptResult{
+			Success: false,
+			Message: fmt.Sprintf("%s doesn't have enough stamina for shield bash!", attacker.Name),
+		}
+	}
+
+	// Deduct stamina
+	attacker.Stamina -= bashDef.StaminaCost
+
+	// Build result
+	result := &InterruptResult{
+		Success:       true,
+		Type:          InterruptShieldBash,
+		AttackerID:    attacker.ID,
+		DefenderID:    target.ID,
+		CounterDamage: bashDef.BaseDamage,
+		StunDuration:  2, // 2 tick stun
+	}
+
+	// Cancel any channeling action
+	if target.CurrentAction != nil {
+		result.ActionCancelled = target.CurrentAction.Action.ID
+		result.Message = fmt.Sprintf("%s's shield bash interrupts %s's %s!", attacker.Name, target.Name, target.CurrentAction.Action.ID)
+	} else {
+		result.Message = fmt.Sprintf("%s shield bashes %s!", attacker.Name, target.Name)
+	}
+
+	// Clear the target's current action
+	target.CurrentAction = nil
+
+	// Apply stun effect
+	stunEffect := CreateStatusEffect(StatusStunned, target.ID, attacker.ID)
+	if stunEffect != nil && combat.Effects != nil {
+		combat.Effects.ApplyEffect(stunEffect)
+	}
+
+	return result
+}
+
+// StunInterrupt applies a stun to interrupt actions
+func StunInterrupt(combat *Combat, attacker *Participant, target *Participant, duration int) *InterruptResult {
+	result := &InterruptResult{
+		Success:      true,
+		Type:         InterruptStun,
+		AttackerID:   attacker.ID,
+		DefenderID:   target.ID,
+		StunDuration: duration,
+	}
+
+	// Cancel any channeling action
+	if target.CurrentAction != nil {
+		result.ActionCancelled = target.CurrentAction.Action.ID
+		result.Message = fmt.Sprintf("%s is stunned, cancelling %s!", target.Name, target.CurrentAction.Action.ID)
+	} else {
+		result.Message = fmt.Sprintf("%s is stunned for %d ticks!", target.Name, duration)
+	}
+
+	// Clear current action
+	target.CurrentAction = nil
+
+	// Apply stun effect
+	stunEffect := CreateStatusEffect(StatusStunned, target.ID, attacker.ID)
+	if stunEffect != nil {
+		stunEffect.TicksRemaining = duration
+		if combat.Effects != nil {
+			combat.Effects.ApplyEffect(stunEffect)
+		}
+	}
+
+	return result
+}
+
+// CheckParryTiming checks if a parry can intercept an attack
+// Parry must be used on the same tick as the attack
+func CheckParryTiming(defenderAction *QueuedAction, attackerAction *QueuedAction, currentTick int) bool {
+	// Defender must be using parry action
+	if defenderAction.Action == nil || defenderAction.Action.ID != "parry" {
+		return false
+	}
+
+	// Attacker must be using an attack
+	if attackerAction.Action == nil || !attackerAction.Action.IsOffensive {
+		return false
+	}
+
+	// Must be same tick (parry is instant, attack resolves this tick)
+	return true
+}
+
+// CanInterrupt checks if an action can be interrupted
+func CanInterrupt(action *QueuedAction) bool {
+	if action == nil || action.Action == nil {
+		return false
+	}
+
+	// Channeling actions can be interrupted
+	if action.Action.Type == ActionChannel {
+		return true
+	}
+
+	// Charging actions can be interrupted
+	if action.Action.Type == ActionCharge && action.ChargeTick > 0 {
+		return true
+	}
+
+	return false
+}
+
+// ProcessInterrupt processes an interrupt and applies its effects
+func ProcessInterrupt(combat *Combat, result *InterruptResult) {
+	if result == nil || !result.Success {
+		return
+	}
+
+	attacker := combat.GetParticipantByID(result.AttackerID)
+	target := combat.GetParticipantByID(result.DefenderID)
+
+	if target == nil {
+		return
+	}
+
+	// Apply counter/ability damage
+	if result.CounterDamage > 0 && attacker != nil {
+		target.TakeDamage(result.CounterDamage)
+		combat.AddLogEntry(CombatLogEntry{
+			Tick:      combat.TickNumber,
+			Message:   result.Message,
+			Type:      "damage",
+			SourceID:  result.AttackerID,
+			TargetID:  result.DefenderID,
+			Value:     result.CounterDamage,
+		})
+	}
+
+	// Add log entry if no damage
+	if result.CounterDamage == 0 {
+		combat.AddLogEntry(CombatLogEntry{
+			Tick:    combat.TickNumber,
+			Message: result.Message,
+			Type:    "interrupt",
+		})
+	}
+}
+
+// ResolveParryOnTick resolves parry attempts for a given tick
+// Called when processing actions - if a parry matches an incoming attack, it interrupts
+func ResolveParryOnTick(combat *Combat, tickActions []*QueuedAction) map[int]*InterruptResult {
+	results := make(map[int]*InterruptResult)
+
+	// Find parry actions
+	parryActions := make(map[int]*QueuedAction) // defenderID -> action
+	attackActions := make(map[int][]*QueuedAction) // targetID -> attacker actions
+
+	for _, action := range tickActions {
+		if action.Action == nil {
+			continue
+		}
+
+		if action.Action.ID == "parry" {
+			parryActions[action.Source.ID] = action
+		}
+
+		if action.Action.IsOffensive && action.Target != nil {
+			attackActions[action.Target.ID] = append(attackActions[action.Target.ID], action)
+		}
+	}
+
+	// Match parries to attacks
+	for defenderID, _ := range parryActions {
+		parryAct := parryActions[defenderID]
+		defender := combat.GetParticipantByID(defenderID)
+		if defender == nil {
+			continue
+		}
+
+		// Check if any attacks target this defender
+		attacks := attackActions[defenderID]
+		if len(attacks) == 0 {
+			continue
+		}
+
+		// Parry the first attack
+		attackerAction := attacks[0]
+		result := ParryAttempt(combat, defender, attackerAction)
+		if result != nil && result.Success {
+			results[defenderID] = result
+		}
+		_ = parryAct // parry action tracked for potential future use
+	}
+
+	return results
+}
+
+// ApplyStunFromAction applies stun from an action (e.g., Shield Bash)
+func ApplyStunFromAction(combat *Combat, action *QueuedAction, target *Participant, duration int) bool {
+	// Get attacker
+	if action.Source == nil {
+		return false
+	}
+	attacker := action.Source
+
+	// Create stun effect
+	stunEffect := CreateStatusEffect(StatusStunned, target.ID, attacker.ID)
+	if stunEffect == nil {
+		return false
+	}
+
+	stunEffect.TicksRemaining = duration
+
+	// Apply to effect registry
+	if combat.Effects != nil {
+		combat.Effects.ApplyEffect(stunEffect)
+	}
+
+	return true
+}

--- a/herbst/combat/interrupt_test.go
+++ b/herbst/combat/interrupt_test.go
@@ -1,0 +1,409 @@
+package combat
+
+import (
+	"testing"
+)
+
+func TestParryAttempt_Success(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, Stamina: 20, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsPlayer: false, Team: 1, HP: 30, MaxHP: 30, IsAlive: true},
+		},
+		Effects: NewEffectRegistry(),
+	}
+
+	defender := combat.Participants[0]
+	attacker := combat.Participants[1]
+
+	attackDef, _ := GetActionDefinition("attack")
+	attackerAction := &QueuedAction{
+		Action: attackDef,
+		Source: attacker,
+		Target: defender,
+	}
+
+	result := ParryAttempt(combat, defender, attackerAction)
+
+	if result == nil {
+		t.Fatal("Expected parry result, got nil")
+	}
+	if !result.Success {
+		t.Errorf("Expected successful parry, got failure: %s", result.Message)
+	}
+	if result.Type != InterruptParry {
+		t.Errorf("Expected PARRY type, got %s", result.Type)
+	}
+	if result.DefenderID != defender.ID {
+		t.Errorf("Expected defender ID %d, got %d", defender.ID, result.DefenderID)
+	}
+}
+
+func TestParryAttempt_NoStamina(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, Stamina: 5, IsAlive: true}, // Not enough stamina
+			{ID: 2, Name: "Enemy", IsPlayer: false, Team: 1, HP: 30, MaxHP: 30, IsAlive: true},
+		},
+		Effects: NewEffectRegistry(),
+	}
+
+	defender := combat.Participants[0]
+	attacker := combat.Participants[1]
+
+	attackDef, _ := GetActionDefinition("attack")
+	attackerAction := &QueuedAction{
+		Action: attackDef,
+		Source: attacker,
+		Target: defender,
+	}
+
+	result := ParryAttempt(combat, defender, attackerAction)
+
+	if result == nil {
+		t.Fatal("Expected result, got nil")
+	}
+	if result.Success {
+		t.Error("Expected parry to fail due to no stamina")
+	}
+}
+
+func TestShieldBashAttempt_Success(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, Stamina: 20, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsPlayer: false, Team: 1, HP: 30, MaxHP: 30, IsAlive: true},
+		},
+		Effects: NewEffectRegistry(),
+	}
+
+	attacker := combat.Participants[0]
+	target := combat.Participants[1]
+
+	// Set up enemy channeling an action
+	fireballDef, _ := GetActionDefinition("fireball")
+	target.CurrentAction = &QueuedAction{
+		Action: fireballDef,
+		Source: target,
+	}
+
+	result := ShieldBashAttempt(combat, attacker, target)
+
+	if result == nil {
+		t.Fatal("Expected result, got nil")
+	}
+	if !result.Success {
+		t.Errorf("Expected successful shield bash, got failure: %s", result.Message)
+	}
+	if result.Type != InterruptShieldBash {
+		t.Errorf("Expected SHIELD_BASH type, got %s", result.Type)
+	}
+	if result.ActionCancelled != "fireball" {
+		t.Errorf("Expected 'fireball' action cancelled, got '%s'", result.ActionCancelled)
+	}
+	if result.StunDuration != 2 {
+		t.Errorf("Expected 2 tick stun, got %d", result.StunDuration)
+	}
+
+	// Check stun was applied
+	if !combat.Effects.IsStunned(target.ID) {
+		t.Error("Expected target to be stunned")
+	}
+}
+
+func TestShieldBashAttempt_InterruptsChannel(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, Stamina: 20, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsPlayer: false, Team: 1, HP: 30, MaxHP: 30, IsAlive: true},
+		},
+		Effects: NewEffectRegistry(),
+	}
+
+	attacker := combat.Participants[0]
+	target := combat.Participants[1]
+
+	// Enemy is channeling a powerful attack
+	fireballDef, _ := GetActionDefinition("fireball")
+	target.CurrentAction = &QueuedAction{
+		Action: fireballDef,
+		Source: target,
+	}
+
+	result := ShieldBashAttempt(combat, attacker, target)
+
+	// Check channel was cancelled
+	if target.CurrentAction != nil {
+		t.Error("Expected target's current action to be cancelled")
+	}
+	if result.ActionCancelled != "fireball" {
+		t.Errorf("Expected 'fireball' to be cancelled, got '%s'", result.ActionCancelled)
+	}
+}
+
+func TestStunInterrupt(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsPlayer: false, Team: 1, HP: 30, MaxHP: 30, IsAlive: true},
+		},
+		Effects: NewEffectRegistry(),
+	}
+
+	attacker := combat.Participants[0]
+	target := combat.Participants[1]
+
+	result := StunInterrupt(combat, attacker, target, 3)
+
+	if result == nil {
+		t.Fatal("Expected result, got nil")
+	}
+	if !result.Success {
+		t.Error("Expected successful stun")
+	}
+	if result.StunDuration != 3 {
+		t.Errorf("Expected 3 tick stun, got %d", result.StunDuration)
+	}
+
+	// Check stun was applied
+	if !combat.Effects.IsStunned(target.ID) {
+		t.Error("Expected target to be stunned")
+	}
+}
+
+func TestCanInterrupt_Channel(t *testing.T) {
+	// Create a channeling action that can be interrupted
+	// Using channel_mana which is defined as ActionChannel
+	channelDef, _ := GetActionDefinition("channel_mana")
+	if channelDef == nil {
+		t.Skip("channel_mana action not defined")
+	}
+	
+	channelAction := &QueuedAction{
+		Action: channelDef,
+	}
+
+	if !CanInterrupt(channelAction) {
+		t.Error("Channeling action should be interruptible")
+	}
+}
+
+func TestCanInterrupt_Charge(t *testing.T) {
+	// Charging action (still charging) can be interrupted
+	heavyStrikeDef, _ := GetActionDefinition("heavy_strike")
+	chargeAction := &QueuedAction{
+		Action:     heavyStrikeDef,
+		ChargeTick: 1, // Still charging
+	}
+
+	if !CanInterrupt(chargeAction) {
+		t.Error("Charging action should be interruptible")
+	}
+
+	// Fully charged action is not interruptible
+	readyAction := &QueuedAction{
+		Action:     heavyStrikeDef,
+		ChargeTick: 0,
+	}
+
+	if CanInterrupt(readyAction) {
+		t.Error("Ready charged action should not be interruptible")
+	}
+}
+
+func TestCanInterrupt_Instant(t *testing.T) {
+	// Instant action cannot be interrupted
+	attackDef, _ := GetActionDefinition("attack")
+	instantAction := &QueuedAction{
+		Action: attackDef,
+	}
+
+	if CanInterrupt(instantAction) {
+		t.Error("Instant action should not be interruptible")
+	}
+}
+
+func TestCheckParryTiming_Valid(t *testing.T) {
+	// Parry action
+	parryDef, _ := GetActionDefinition("parry")
+	parryAction := &QueuedAction{
+		Action: parryDef,
+	}
+
+	// Attack action targeting the parrying player
+	attackDef, _ := GetActionDefinition("attack")
+	attackAction := &QueuedAction{
+		Action: attackDef,
+	}
+
+	// Same tick check
+	valid := CheckParryTiming(parryAction, attackAction, 1)
+	if !valid {
+		t.Error("Parry should be valid against attack on same tick")
+	}
+}
+
+func TestCheckParryTiming_WrongAction(t *testing.T) {
+	// Not a parry
+	defendDef, _ := GetActionDefinition("defend")
+	defendAction := &QueuedAction{
+		Action: defendDef,
+	}
+
+	attackDef, _ := GetActionDefinition("attack")
+	attackAction := &QueuedAction{
+		Action: attackDef,
+	}
+
+	valid := CheckParryTiming(defendAction, attackAction, 1)
+	if valid {
+		t.Error("Defend should not count as parry")
+	}
+}
+
+func TestProcessInterrupt_Damage(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsPlayer: false, Team: 1, HP: 30, MaxHP: 30, IsAlive: true},
+		},
+		Effects: NewEffectRegistry(),
+	}
+
+	attacker := combat.Participants[0]
+	target := combat.Participants[1]
+
+	result := &InterruptResult{
+		Success:       true,
+		Type:          InterruptShieldBash,
+		AttackerID:    attacker.ID,
+		DefenderID:    target.ID,
+		CounterDamage: 8,
+		Message:       "Player shield bashes Enemy!",
+	}
+
+	ProcessInterrupt(combat, result)
+
+	// Check damage was applied
+	if target.HP != 22 {
+		t.Errorf("Expected target HP 22, got %d", target.HP)
+	}
+
+	// Check log entry
+	if len(combat.Log) != 1 {
+		t.Errorf("Expected 1 log entry, got %d", len(combat.Log))
+	}
+}
+
+func TestProcessInterrupt_NoDamage(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsPlayer: false, Team: 1, HP: 30, MaxHP: 30, IsAlive: true},
+		},
+		Effects: NewEffectRegistry(),
+	}
+
+	result := &InterruptResult{
+		Success:      true,
+		Type:         InterruptStun,
+		AttackerID:   1,
+		DefenderID:   2,
+		StunDuration: 2,
+		Message:      "Enemy is stunned for 2 ticks!",
+	}
+
+	ProcessInterrupt(combat, result)
+
+	// Check log entry exists
+	if len(combat.Log) != 1 {
+		t.Errorf("Expected 1 log entry, got %d", len(combat.Log))
+	}
+	if combat.Log[0].Type != "interrupt" {
+		t.Errorf("Expected log type 'interrupt', got '%s'", combat.Log[0].Type)
+	}
+}
+
+func TestApplyStunFromAction(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsPlayer: false, Team: 1, HP: 30, MaxHP: 30, IsAlive: true},
+		},
+		Effects: NewEffectRegistry(),
+	}
+
+	attackDef, _ := GetActionDefinition("attack")
+	action := &QueuedAction{
+		Action: attackDef,
+		Source: combat.Participants[0],
+	}
+
+	target := combat.Participants[1]
+
+	success := ApplyStunFromAction(combat, action, target, 2)
+
+	if !success {
+		t.Error("Expected successful stun application")
+	}
+
+	// Check stun was applied
+	if !combat.Effects.IsStunned(target.ID) {
+		t.Error("Expected target to be stunned")
+	}
+}
+
+func TestResolveParryOnTick(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, Stamina: 20, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsPlayer: false, Team: 1, HP: 30, MaxHP: 30, IsAlive: true},
+		},
+		Effects: NewEffectRegistry(),
+	}
+
+	player := combat.Participants[0]
+	enemy := combat.Participants[1]
+
+	parryDef, _ := GetActionDefinition("parry")
+	attackDef, _ := GetActionDefinition("attack")
+
+	actions := []*QueuedAction{
+		{Action: parryDef, Source: player, Target: enemy},
+		{Action: attackDef, Source: enemy, Target: player},
+	}
+
+	results := ResolveParryOnTick(combat, actions)
+
+	// Should have one parry result
+	if len(results) != 1 {
+		t.Errorf("Expected 1 parry result, got %d", len(results))
+	}
+
+	parryResult, exists := results[1] // Player's parry
+	if !exists {
+		t.Fatal("Expected parry result for player (ID 1)")
+	}
+
+	if !parryResult.Success {
+		t.Error("Expected successful parry")
+	}
+}

--- a/herbst/combat/manager_test.go
+++ b/herbst/combat/manager_test.go
@@ -1,0 +1,126 @@
+package combat
+
+import (
+	"testing"
+)
+
+func TestCombatManager_CreateCombat(t *testing.T) {
+	cm := NewCombatManager()
+	
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, HP: 100, MaxHP: 100, Dexterity: 15},
+		{ID: 2, Name: "Goblin", IsNPC: true, Team: 1, HP: 30, MaxHP: 30, Dexterity: 10},
+	}
+	
+	id := cm.CreateCombat(5, participants)
+	
+	if id != 1 {
+		t.Errorf("Expected combat ID 1, got %d", id)
+	}
+	
+	combat, exists := cm.GetCombat(id)
+	if !exists {
+		t.Error("Combat should exist after creation")
+	}
+	
+	if len(combat.Participants) != 2 {
+		t.Errorf("Expected 2 participants, got %d", len(combat.Participants))
+	}
+}
+
+func TestCombatManager_EndCombat(t *testing.T) {
+	cm := NewCombatManager()
+	
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", IsPlayer: true, Team: 0},
+		{ID: 2, Name: "Goblin", IsNPC: true, Team: 1},
+	}
+	
+	id := cm.CreateCombat(5, participants)
+	cm.EndCombat(id, "test end")
+	
+	_, exists := cm.GetCombat(id)
+	if exists {
+		t.Error("Combat should not exist after ending")
+	}
+	
+	if count := cm.GetCombatCount(); count != 0 {
+		t.Errorf("Expected 0 combats, got %d", count)
+	}
+}
+
+func TestCombatManager_GetCombatsByRoom(t *testing.T) {
+	cm := NewCombatManager()
+	
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", IsPlayer: true, Team: 0},
+	}
+	
+	_ = cm.CreateCombat(5, participants)
+	_ = cm.CreateCombat(10, participants)
+	
+	room5Combats := cm.GetCombatsByRoom(5)
+	if len(room5Combats) != 1 {
+		t.Errorf("Expected 1 combat in room 5, got %d", len(room5Combats))
+	}
+	
+	room10Combats := cm.GetCombatsByRoom(10)
+	if len(room10Combats) != 1 {
+		t.Errorf("Expected 1 combat in room 10, got %d", len(room10Combats))
+	}
+	
+	room99Combats := cm.GetCombatsByRoom(99)
+	if len(room99Combats) != 0 {
+		t.Errorf("Expected 0 combats in room 99, got %d", len(room99Combats))
+	}
+}
+
+func TestCombat_GetAliveParticipants(t *testing.T) {
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, IsAlive: true, HP: 100},
+		{ID: 2, Name: "Goblin", IsNPC: true, Team: 1, IsAlive: false, HP: 0},
+		{ID: 3, Name: "Orc", IsNPC: true, Team: 1, IsAlive: true, HP: 50},
+	}
+	
+	combat := &Combat{
+		ID:           1,
+		Participants: participants,
+	}
+	
+	alive := combat.GetAliveParticipants()
+	if len(alive) != 2 {
+		t.Errorf("Expected 2 alive participants, got %d", len(alive))
+	}
+}
+
+func TestCombat_AllEnemiesDefeated(t *testing.T) {
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, IsAlive: true, HP: 100},
+		{ID: 2, Name: "Goblin", IsNPC: true, Team: 1, IsAlive: false, HP: 0},
+	}
+	
+	combat := &Combat{
+		ID:           1,
+		Participants: participants,
+	}
+	
+	if !combat.AllEnemiesDefeated() {
+		t.Error("All enemies should be defeated")
+	}
+}
+
+func TestCombat_AllPlayersDefeated(t *testing.T) {
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, IsAlive: false, HP: 0},
+		{ID: 2, Name: "Goblin", IsNPC: true, Team: 1, IsAlive: true, HP: 30},
+	}
+	
+	combat := &Combat{
+		ID:           1,
+		Participants: participants,
+	}
+	
+	if !combat.AllPlayersDefeated() {
+		t.Error("All players should be defeated")
+	}
+}

--- a/herbst/combat/result.go
+++ b/herbst/combat/result.go
@@ -1,0 +1,244 @@
+package combat
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+// VictoryResult contains the results of winning a combat
+type VictoryResult struct {
+	Loot          []LootItem     `json:"loot"`
+	Coins         int            `json:"coins"`
+	XP            int            `json:"xp"`
+	SkillUps      []SkillUp      `json:"skillUps"`
+	WeaponDrops   []WeaponDrop   `json:"weaponDrops,omitempty"`
+	CombatLog     []string       `json:"combatLog"`
+	VictoryTime   time.Time      `json:"victoryTime"`
+}
+
+// LootItem represents an item dropped by enemies
+type LootItem struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Quantity    int    `json:"quantity"`
+	Rarity      string `json:"rarity"` // "common", "uncommon", "rare", "legendary"
+}
+
+// SkillUp represents skill experience gained
+type SkillUp struct {
+	SkillName string `json:"skillName"`
+	Amount    int    `json:"amount"`
+	NewLevel  int    `json:"newLevel"`
+}
+
+// DefeatResult contains the consequences of losing a combat
+type DefeatResult struct {
+	XPLost          int            `json:"xpLost"`
+	ItemDropped     *LootItem      `json:"itemDropped,omitempty"`
+	RespawnPoint    int            `json:"respawnPoint"` // Room ID
+	CorpseLocation  int            `json:"corpseLocation"` // Room ID
+	CorpseExpiry    time.Time      `json:"corpseExpiry"`
+	Consequences    []string       `json:"consequences"`
+	DefeatTime      time.Time      `json:"defeatTime"`
+}
+
+// HandleVictory processes the victory and calculates rewards
+func (c *Combat) HandleVictory() *VictoryResult {
+	result := &VictoryResult{
+		VictoryTime: time.Now(),
+	}
+
+	// Get all defeated NPCs
+	for _, p := range c.Participants {
+		if p.IsNPC && !p.IsAlive {
+			// Generate loot from this NPC
+			loot := generateNPCLoot(p)
+			result.Loot = append(result.Loot, loot...)
+
+			// Add coins
+			result.Coins += rand.Intn(50) + 10 // 10-60 coins per enemy
+
+			// Add XP
+			result.XP += calculateEnemyXP(p)
+
+			// Check for weapon drop
+			if p.HasGuaranteedDrop && p.DropWeapon != "" {
+				drop := WeaponDrop{
+					Name:             p.DropWeapon,
+					WeaponType:       getWeaponType(p.DropWeapon),
+					ClassRestriction: getClassRestriction(p.DropWeapon),
+					MinDamage:        4,
+					MaxDamage:        8,
+					Guaranteed:       true,
+				}
+				result.WeaponDrops = append(result.WeaponDrops, drop)
+			}
+		}
+	}
+
+	// Calculate skill ups for skills used in combat
+	// For now, we'll give skill XP based on actions taken
+	result.SkillUps = calculateSkillUps(c)
+
+	// Copy combat log
+	for _, entry := range c.Log {
+		result.CombatLog = append(result.CombatLog, entry.Message)
+	}
+
+	return result
+}
+
+// HandleDefeat processes the defeat and calculates consequences
+func (c *Combat) HandleDefeat(playerStartingRoom int) *DefeatResult {
+	result := &DefeatResult{
+		DefeatTime:     time.Now(),
+		RespawnPoint:   playerStartingRoom, // Default to starting area
+		CorpseExpiry:   time.Now().Add(5 * time.Minute),
+	}
+
+	// Find the player who died
+	var player *Participant
+	for _, p := range c.Participants {
+		if p.IsPlayer && !p.IsAlive {
+			player = p
+			break
+		}
+	}
+
+	if player == nil {
+		// No dead player found (shouldn't happen, but handle gracefully)
+		return result
+	}
+
+	// Calculate XP loss (10% of current level progress)
+	result.XPLost = 0 // This would be calculated from player's current XP
+	result.Consequences = append(result.Consequences, 
+		fmt.Sprintf("Lose %d XP (10%% of current level progress)", result.XPLost))
+
+	// Store corpse location
+	result.CorpseLocation = c.RoomID
+	result.Consequences = append(result.Consequences, 
+		"Your equipment has been left in the combat area")
+
+	// Add respawn info
+	result.Consequences = append(result.Consequences, 
+		"Return within 5 minutes to reclaim your equipment!")
+
+	return result
+}
+
+// generateNPCLoot generates loot items for a defeated NPC
+func generateNPCLoot(npc *Participant) []LootItem {
+	var items []LootItem
+
+	// Base loot - enemy-specific items would come from a definition
+	// For now, generate generic salvage items
+	salvageItems := []LootItem{
+		{ID: 1, Name: "Rusty Pipe", Description: "A bent metal pipe, slightly corroded", Quantity: 1, Rarity: "common"},
+		{ID: 2, Name: "Scrap Metal", Description: "Twisted metal fragments", Quantity: rand.Intn(3) + 1, Rarity: "common"},
+		{ID: 3, Name: "Ragged Cloth", Description: "Torn fabric scraps", Quantity: rand.Intn(2) + 1, Rarity: "common"},
+	}
+
+	// Random chance for better loot
+	roll := rand.Float64()
+	if roll < 0.3 { // 30% chance for uncommon
+		items = append(items, LootItem{
+			ID:          10,
+			Name:        "Polished Gear",
+			Description: "A well-maintained mechanical gear",
+			Quantity:     1,
+			Rarity:      "uncommon",
+		})
+	}
+
+	if roll < 0.1 { // 10% chance for rare
+		items = append(items, LootItem{
+			ID:          20,
+			Name:        "Crystal Shard",
+			Description: "A glowing crystal fragment",
+			Quantity:     1,
+			Rarity:      "rare",
+		})
+	}
+
+	// Add base salvage
+	items = append(items, salvageItems[rand.Intn(len(salvageItems))])
+
+	return items
+}
+
+// calculateEnemyXP calculates XP reward for defeating an enemy
+func calculateEnemyXP(npc *Participant) int {
+	// Base XP based on enemy level
+	baseXP := npc.Level * 15
+
+	// Bonus for tough enemies
+	if npc.MaxHP > 50 {
+		baseXP += 20
+	}
+	if npc.MaxHP > 100 {
+		baseXP += 30
+	}
+
+	return baseXP
+}
+
+// calculateSkillUps calculates skill experience gains from combat
+func calculateSkillUps(combat *Combat) []SkillUp {
+	// For now, return basic skill ups based on combat actions
+	// In a full implementation, this would track which skills were used
+	var skillUps []SkillUp
+
+	// Check if blades was used (warrior)
+	for _, entry := range combat.Log {
+		if entry.Type == "action" {
+			// Check action type and award appropriate skill XP
+			skillUps = append(skillUps, SkillUp{
+				SkillName: "blades",
+				Amount:    2,
+				NewLevel:   0, // Would be current + amount
+			})
+			break
+		}
+	}
+
+	// Also give brawling XP for basic attacks
+	skillUps = append(skillUps, SkillUp{
+		SkillName: "brawling",
+		Amount:    1,
+		NewLevel:  0,
+	})
+
+	return skillUps
+}
+
+// getWeaponType returns the weapon type for a weapon name
+func getWeaponType(name string) string {
+	weaponTypes := map[string]string{
+		"Rusty Sword":      "sword",
+		"Scrap Machete":    "sword",
+		"Twisted Pipe":     "pipe",
+		"Chef's Knife":     "dagger",
+		"Broken Bottle":    "dagger",
+	}
+	if t, ok := weaponTypes[name]; ok {
+		return t
+	}
+	return "weapon"
+}
+
+// getClassRestriction returns class restrictions for a weapon
+func getClassRestriction(name string) string {
+	classRestrictions := map[string]string{
+		"Rusty Sword":      "warrior",
+		"Scrap Machete":    "warrior",
+		"Twisted Pipe":     "chef",
+		"Chef's Knife":     "chef",
+	}
+	if c, ok := classRestrictions[name]; ok {
+		return c
+	}
+	return "" // No restriction
+}

--- a/herbst/combat/result_test.go
+++ b/herbst/combat/result_test.go
@@ -1,0 +1,337 @@
+package combat
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHandleVictory_Basic(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Scrap Rat", IsNPC: true, Team: 1, HP: 0, MaxHP: 20, Level: 1, IsAlive: false},
+		},
+		Log: []CombatLogEntry{
+			{Tick: 1, Message: "Player attacks Scrap Rat", Type: "action"},
+			{Tick: 2, Message: "Scrap Rat takes 15 damage", Type: "damage"},
+		},
+	}
+
+	result := combat.HandleVictory()
+
+	if result == nil {
+		t.Fatal("Expected victory result, got nil")
+	}
+
+	if result.XP < 1 {
+		t.Errorf("Expected XP reward, got %d", result.XP)
+	}
+
+	if len(result.Loot) == 0 {
+		t.Error("Expected loot items from defeated enemy")
+	}
+
+	if result.VictoryTime.IsZero() {
+		t.Error("Expected victory time to be set")
+	}
+}
+
+func TestHandleVictory_MultipleEnemies(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Rat A", IsNPC: true, Team: 1, HP: 0, MaxHP: 15, Level: 1, IsAlive: false},
+			{ID: 3, Name: "Rat B", IsNPC: true, Team: 1, HP: 0, MaxHP: 15, Level: 1, IsAlive: false},
+			{ID: 4, Name: "Rat C", IsNPC: true, Team: 1, HP: 0, MaxHP: 15, Level: 2, IsAlive: false},
+		},
+		Log: []CombatLogEntry{},
+	}
+
+	result := combat.HandleVictory()
+
+	// Should get XP from all defeated enemies
+	if result.XP < 3 {
+		t.Errorf("Expected XP from 3 enemies, got %d", result.XP)
+	}
+
+	// Should have loot from all enemies
+	if len(result.Loot) < 1 {
+		t.Error("Expected loot from multiple enemies")
+	}
+}
+
+func TestHandleVictory_WeaponDrop(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Old Scrap", IsNPC: true, Team: 1, HP: 0, MaxHP: 100, Level: 5, IsAlive: false,
+				HasGuaranteedDrop: true, DropWeapon: "Scrap Machete"},
+		},
+		Log: []CombatLogEntry{},
+	}
+
+	result := combat.HandleVictory()
+
+	// Should have a weapon drop
+	if len(result.WeaponDrops) == 0 {
+		t.Fatal("Expected weapon drop from guaranteed enemy")
+	}
+
+	drop := result.WeaponDrops[0]
+	if drop.Name != "Scrap Machete" {
+		t.Errorf("Expected 'Scrap Machete', got '%s'", drop.Name)
+	}
+
+	if !drop.Guaranteed {
+		t.Error("Expected guaranteed drop")
+	}
+}
+
+func TestHandleDefeat_Basic(t *testing.T) {
+	combat := &Combat{
+		ID:     1,
+		RoomID: 5, // Junkyard entrance
+		State:  StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 0, MaxHP: 50, IsAlive: false},
+			{ID: 2, Name: "Boss", IsNPC: true, Team: 1, HP: 30, MaxHP: 100, Level: 10, IsAlive: true},
+		},
+		Log: []CombatLogEntry{
+			{Tick: 5, Message: "Boss attacks Player", Type: "action"},
+			{Tick: 5, Message: "Player takes 50 damage", Type: "damage"},
+		},
+	}
+
+	startingRoom := 1 // Foggy Gate
+	result := combat.HandleDefeat(startingRoom)
+
+	if result == nil {
+		t.Fatal("Expected defeat result, got nil")
+	}
+
+	if result.RespawnPoint != startingRoom {
+		t.Errorf("Expected respawn at room %d, got %d", startingRoom, result.RespawnPoint)
+	}
+
+	if result.CorpseLocation != combat.RoomID {
+		t.Errorf("Expected corpse at room %d, got %d", combat.RoomID, result.CorpseLocation)
+	}
+
+	if len(result.Consequences) == 0 {
+		t.Error("Expected defeat consequences")
+	}
+
+	if result.DefeatTime.IsZero() {
+		t.Error("Expected defeat time to be set")
+	}
+}
+
+func TestHandleDefeat_CorpseExpiry(t *testing.T) {
+	combat := &Combat{
+		ID:     1,
+		RoomID: 10,
+		State:  StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 0, MaxHP: 50, IsAlive: false},
+		},
+	}
+
+	result := combat.HandleDefeat(1)
+
+	// Corpse should expire in 5 minutes
+	if result.CorpseExpiry.IsZero() {
+		t.Fatal("Expected corpse expiry to be set")
+	}
+
+	// Should be approximately 5 minutes in the future
+	expectedExpiry := result.DefeatTime.Add(5 * time.Minute)
+	diff := result.CorpseExpiry.Sub(expectedExpiry)
+	if diff > time.Second {
+		t.Errorf("Expected corpse expiry ~5 minutes from defeat, got %v", diff)
+	}
+}
+
+func TestGenerateNPCLoot_CommonItems(t *testing.T) {
+	npc := &Participant{
+		ID:     2,
+		Name:   "Rat",
+		Level:  1,
+		IsNPC:  true,
+	}
+
+	// Run multiple times to check randomness
+	for i := 0; i < 10; i++ {
+		loot := generateNPCLoot(npc)
+		if len(loot) == 0 {
+			t.Error("Expected at least one loot item")
+		}
+
+		for _, item := range loot {
+			if item.Quantity < 1 {
+				t.Error("Expected item quantity >= 1")
+			}
+		}
+	}
+}
+
+func TestCalculateEnemyXP_BasicEnemy(t *testing.T) {
+	npc := &Participant{
+		ID:     2,
+		Name:   "Scrap Rat",
+		Level:  1,
+		MaxHP:  15,
+		IsNPC:  true,
+	}
+
+	xp := calculateEnemyXP(npc)
+
+	// Level 1 enemy = 15 base XP
+	if xp < 15 {
+		t.Errorf("Expected at least 15 XP for level 1 enemy, got %d", xp)
+	}
+}
+
+func TestCalculateEnemyXP_ToughEnemy(t *testing.T) {
+	npc := &Participant{
+		ID:     2,
+		Name:   "Old Scrap",
+		Level:  5,
+		MaxHP:  120, // Tough enemy
+		IsNPC:  true,
+	}
+
+	xp := calculateEnemyXP(npc)
+
+	// Level 5 = 75 base + 20 (HP>50) + 30 (HP>100) = 125
+	if xp < 75 {
+		t.Errorf("Expected at least 75 XP for level 5 tough enemy, got %d", xp)
+	}
+}
+
+func TestGetWeaponType(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"Rusty Sword", "sword"},
+		{"Scrap Machete", "sword"},
+		{"Twisted Pipe", "pipe"},
+		{"Chef's Knife", "dagger"},
+		{"Broken Bottle", "dagger"},
+		{"Unknown Weapon", "weapon"},
+	}
+
+	for _, tt := range tests {
+		result := getWeaponType(tt.name)
+		if result != tt.expected {
+			t.Errorf("getWeaponType(%q) = %q, want %q", tt.name, result, tt.expected)
+		}
+	}
+}
+
+func TestGetClassRestriction(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"Rusty Sword", "warrior"},
+		{"Scrap Machete", "warrior"},
+		{"Twisted Pipe", "chef"},
+		{"Chef's Knife", "chef"},
+		{"Unknown Weapon", ""}, // No restriction
+	}
+
+	for _, tt := range tests {
+		result := getClassRestriction(tt.name)
+		if result != tt.expected {
+			t.Errorf("getClassRestriction(%q) = %q, want %q", tt.name, result, tt.expected)
+		}
+	}
+}
+
+func TestSkillUps(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+		},
+		Log: []CombatLogEntry{
+			{Tick: 1, Message: "Player attacks", Type: "action"},
+		},
+	}
+
+	skillUps := calculateSkillUps(combat)
+
+	if len(skillUps) == 0 {
+		t.Error("Expected skill ups from combat")
+	}
+
+	// Should include brawling for basic attacks
+	foundBrawling := false
+	for _, su := range skillUps {
+		if su.SkillName == "brawling" {
+			foundBrawling = true
+			if su.Amount < 1 {
+				t.Errorf("Expected positive skill amount, got %d", su.Amount)
+			}
+		}
+	}
+
+	if !foundBrawling {
+		t.Error("Expected brawling skill up for basic attacks")
+	}
+}
+
+func TestVictoryResult_LootRarity(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsNPC: true, Team: 1, HP: 0, MaxHP: 20, Level: 1, IsAlive: false},
+		},
+	}
+
+	// Run multiple times to check for different rarities
+	rarities := make(map[string]int)
+	for i := 0; i < 100; i++ {
+		result := combat.HandleVictory()
+		for _, item := range result.Loot {
+			rarities[item.Rarity]++
+		}
+	}
+
+	// Should see common items most often
+	if rarities["common"] == 0 {
+		t.Error("Expected common loot items")
+	}
+
+	// Rare items should be rare (if we see them)
+	// Note: Due to randomness, we might not see rare items in every test run
+}
+
+func TestDefeatResult_XPLoss(t *testing.T) {
+	combat := &Combat{
+		ID:     1,
+		RoomID: 5,
+		State:  StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 0, MaxHP: 50, IsAlive: false},
+		},
+	}
+
+	result := combat.HandleDefeat(1)
+
+	// XP loss should be 0 since we can't calculate it without player data
+	// In a real implementation, this would be 10% of current level XP
+	if result.XPLost < 0 {
+		t.Error("XP loss should not be negative")
+	}
+}

--- a/herbst/combat/state_machine.go
+++ b/herbst/combat/state_machine.go
@@ -1,0 +1,480 @@
+package combat
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// CombatStateMachine manages the lifecycle of a combat encounter
+type CombatStateMachine struct {
+	combat        *Combat
+	combatManager *CombatManager
+	tickManager   *TickManager
+
+	// State transition callbacks
+	onStateEnter map[CombatState]func(*Combat)
+	onStateExit  map[CombatState]func(*Combat)
+	onTick       func(*Combat, Tick)
+
+	// Input handling
+	inputWindow     time.Duration
+	inputDeadline   time.Time
+	awaitingInput   map[int]bool // participantID -> awaiting
+	selectedActions map[int]*QueuedAction // participantID -> action
+
+	// Turn tracking
+	currentTurn     int
+	currentActorIdx int
+
+	// State
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// NewCombatStateMachine creates a new state machine for a combat
+func NewCombatStateMachine(combat *Combat, cm *CombatManager, tm *TickManager) *CombatStateMachine {
+	return &CombatStateMachine{
+		combat:          combat,
+		combatManager:   cm,
+		tickManager:     tm,
+		onStateEnter:    make(map[CombatState]func(*Combat)),
+		onStateExit:     make(map[CombatState]func(*Combat)),
+		awaitingInput:   make(map[int]bool),
+		selectedActions: make(map[int]*QueuedAction),
+		inputWindow:     TickDuration,
+	}
+}
+
+// SetOnStateEnter sets a callback for entering a state
+func (csm *CombatStateMachine) SetOnStateEnter(state CombatState, callback func(*Combat)) {
+	csm.onStateEnter[state] = callback
+}
+
+// SetOnStateExit sets a callback for exiting a state
+func (csm *CombatStateMachine) SetOnStateExit(state CombatState, callback func(*Combat)) {
+	csm.onStateExit[state] = callback
+}
+
+// SetOnTick sets a callback for tick events
+func (csm *CombatStateMachine) SetOnTick(callback func(*Combat, Tick)) {
+	csm.onTick = callback
+}
+
+// TransitionTo changes the combat state and fires callbacks
+func (csm *CombatStateMachine) TransitionTo(newState CombatState) {
+	oldState := csm.combat.State
+
+	// Fire exit callback for old state
+	if callback, exists := csm.onStateExit[oldState]; exists {
+		callback(csm.combat)
+	}
+
+	// Update state
+	csm.combat.State = newState
+
+	// Log state transition
+	log.Printf("[Combat %d] State transition: %s -> %s", csm.combat.ID, oldState, newState)
+	csm.combat.AddLogEntry(CombatLogEntry{
+		Tick:      csm.combat.TickNumber,
+		Timestamp: time.Now(),
+		Message:   string(newState),
+		Type:      "system",
+	})
+
+	// Fire enter callback for new state
+	if callback, exists := csm.onStateEnter[newState]; exists {
+		callback(csm.combat)
+	}
+
+	// Notify combat manager
+	if csm.combatManager != nil {
+		csm.combatManager.ChangeCombatState(csm.combat, newState)
+	}
+}
+
+// Start begins the combat state machine
+func (csm *CombatStateMachine) Start(ctx context.Context) {
+	csm.ctx, csm.cancel = context.WithCancel(ctx)
+
+	// Transition to INIT state
+	csm.TransitionTo(StateInit)
+
+	// Roll initiative for all participants
+	RollAllInitiative(csm.combat.Participants)
+	csm.combat.AddLogEntry(CombatLogEntry{
+		Tick:      0,
+		Timestamp: time.Now(),
+		Message:   "Initiative rolled",
+		Type:      "system",
+	})
+
+	// Sort by initiative
+	order := csm.combat.GetTurnOrder()
+	for i, p := range order {
+		csm.combat.AddLogEntry(CombatLogEntry{
+			Tick:      0,
+			Timestamp: time.Now(),
+			Message:   FormatCombatLog("%s rolls %d initiative", p.Name, p.Initiative),
+			Type:      "info",
+		})
+		_ = i // position in turn order
+	}
+
+	// Start input window for first turn
+	csm.TransitionTo(StateActive)
+	csm.startInputWindow()
+
+	// Start processing ticks
+	go csm.processTicks()
+}
+
+// Stop halts the state machine
+func (csm *CombatStateMachine) Stop() {
+	if csm.cancel != nil {
+		csm.cancel()
+	}
+}
+
+// startInputWindow begins the input window for the current actor
+func (csm *CombatStateMachine) startInputWindow() {
+	// Get current actor
+	order := csm.combat.GetTurnOrder()
+	if len(order) == 0 {
+		return
+	}
+
+	// Find next alive actor
+	for i := 0; i < len(order); i++ {
+		idx := (csm.currentActorIdx + i) % len(order)
+		actor := order[idx]
+		if actor.IsAlive && actor.CanAct() {
+			csm.currentActorIdx = idx
+			csm.awaitingInput[actor.ID] = true
+			csm.inputDeadline = time.Now().Add(csm.inputWindow)
+			csm.combat.TickCountdown = float64(csm.inputWindow) / float64(time.Second)
+			csm.combat.AddLogEntry(CombatLogEntry{
+				Tick:      csm.combat.TickNumber,
+				Timestamp: time.Now(),
+				Message:   FormatCombatLog("Waiting for %s's action", actor.Name),
+				Type:      "system",
+			})
+			return
+		}
+	}
+
+	// No alive actors who can act
+	csm.checkEndCondition()
+}
+
+// processTicks handles the tick loop
+func (csm *CombatStateMachine) processTicks() {
+	if csm.tickManager == nil {
+		return
+	}
+
+	tickChan := csm.tickManager.Subscribe(int(csm.combat.ID))
+	defer csm.tickManager.Unsubscribe(int(csm.combat.ID))
+
+	for {
+		select {
+		case <-csm.ctx.Done():
+			return
+		case tick := <-tickChan:
+			csm.processTick(tick)
+		}
+	}
+}
+
+// processTick handles a single combat tick
+func (csm *CombatStateMachine) processTick(tick Tick) {
+	// Skip if combat ended
+	if csm.combat.State == StateEnded {
+		return
+	}
+
+	// Fire tick callback
+	if csm.onTick != nil {
+		csm.onTick(csm.combat, tick)
+	}
+
+	// Increment tick counter
+	csm.combat.TickNumber = tick.ID
+
+	// Process pending actions
+	csm.processPendingActions()
+
+	// Process effects (DoT, HoT, buffs/debuffs)
+	csm.processEffects()
+
+	// Check end condition
+	if csm.checkEndCondition() {
+		return
+	}
+
+	// Advance to next turn
+	csm.advanceTurn()
+}
+
+// processPendingActions executes queued actions
+func (csm *CombatStateMachine) processPendingActions() {
+	// Get actions for this tick
+	actions := csm.combat.ActionQueue.GetActionsForTick(csm.combat.TickNumber)
+
+	for _, qa := range actions {
+		// Skip if source is dead
+		if !qa.Source.IsAlive {
+			continue
+		}
+
+		// Execute the action
+		csm.executeAction(qa)
+
+		// Remove from queue
+		csm.combat.ActionQueue.Remove(qa)
+	}
+}
+
+// executeAction executes a queued action
+func (csm *CombatStateMachine) executeAction(qa *QueuedAction) {
+	action := qa.Action
+	source := qa.Source
+	target := qa.Target
+
+	// Log action
+	csm.combat.AddLogEntry(CombatLogEntry{
+		Tick:      csm.combat.TickNumber,
+		Timestamp: time.Now(),
+		SourceID:  source.ID,
+		TargetID:  target.ID,
+		Type:      "action",
+		Message:   FormatCombatLog("%s uses %s", source.Name, action.Name),
+	})
+
+	// Apply damage/healing
+	if action.BaseDamage > 0 && target != nil {
+		damage := action.BaseDamage
+		actualDamage := target.TakeDamage(damage)
+		csm.combat.AddLogEntry(CombatLogEntry{
+			Tick:      csm.combat.TickNumber,
+			Timestamp: time.Now(),
+			SourceID:  source.ID,
+			TargetID:  target.ID,
+			Type:      "damage",
+			Value:     actualDamage,
+			Message:   FormatCombatLog("%s takes %d damage", target.Name, actualDamage),
+		})
+	}
+
+	if action.BaseHeal > 0 && target != nil {
+		heal := action.BaseHeal
+		actualHeal := target.Heal(heal)
+		csm.combat.AddLogEntry(CombatLogEntry{
+			Tick:      csm.combat.TickNumber,
+			Timestamp: time.Now(),
+			SourceID:  source.ID,
+			TargetID:  target.ID,
+			Type:      "heal",
+			Value:     actualHeal,
+			Message:   FormatCombatLog("%s heals for %d", target.Name, actualHeal),
+		})
+	}
+}
+
+// processEffects handles ongoing effects (DoT, HoT, etc.)
+func (csm *CombatStateMachine) processEffects() {
+	// Process all effects
+	damageEffects, healEffects := csm.combat.Effects.ProcessEffects(csm.combat.Participants)
+
+	// Log DoT effects
+	for _, e := range damageEffects {
+		csm.combat.AddLogEntry(CombatLogEntry{
+			Tick:      csm.combat.TickNumber,
+			Timestamp: time.Now(),
+			TargetID:  e.Target.ID,
+			Type:      "damage",
+			Value:     e.Value,
+			Message:   FormatCombatLog("%s takes %d damage from %s", e.Target.Name, e.Value, e.Effect.Name),
+		})
+	}
+
+	// Log HoT effects
+	for _, e := range healEffects {
+		csm.combat.AddLogEntry(CombatLogEntry{
+			Tick:      csm.combat.TickNumber,
+			Timestamp: time.Now(),
+			TargetID:  e.Target.ID,
+			Type:      "heal",
+			Value:     e.Value,
+			Message:   FormatCombatLog("%s heals for %d from %s", e.Target.Name, e.Value, e.Effect.Name),
+		})
+	}
+}
+
+// checkEndCondition checks if combat should end
+func (csm *CombatStateMachine) checkEndCondition() bool {
+	if csm.combat.AllEnemiesDefeated() {
+		csm.endCombat("victory", "All enemies defeated!")
+		return true
+	}
+
+	if csm.combat.AllPlayersDefeated() {
+		csm.endCombat("defeat", "All players defeated!")
+		return true
+	}
+
+	return false
+}
+
+// endCombat transitions to ended state
+func (csm *CombatStateMachine) endCombat(result, reason string) {
+	csm.combat.EndedAt = time.Now()
+	csm.combat.AddLogEntry(CombatLogEntry{
+		Tick:      csm.combat.TickNumber,
+		Timestamp: time.Now(),
+		Type:      "system",
+		Message:   FormatCombatLog("Combat ended: %s - %s", result, reason),
+	})
+
+	// Handle weapon drops on NPC defeat (victory)
+	if result == "victory" {
+		csm.handleWeaponDrops()
+	}
+
+	csm.TransitionTo(StateEnded)
+
+	if csm.combatManager != nil {
+		csm.combatManager.EndCombat(csm.combat.ID, reason)
+	}
+}
+
+// handleWeaponDrops processes weapon drops when enemies are defeated
+func (csm *CombatStateMachine) handleWeaponDrops() {
+	// Get all defeated NPCs in this combat
+	for _, participant := range csm.combat.Participants {
+		if participant.IsNPC && !participant.IsAlive {
+			// NPC was defeated - check if it has a guaranteed drop
+			csm.combat.AddLogEntry(CombatLogEntry{
+				Tick:      csm.combat.TickNumber,
+				Timestamp: time.Now(),
+				Type:      "loot",
+				TargetID:  participant.ID,
+				Message:   FormatCombatLog("%s has been defeated!", participant.Name),
+			})
+
+			// Log that a weapon can be picked up (actual pickup happens via game command)
+			csm.combat.AddLogEntry(CombatLogEntry{
+				Tick:      csm.combat.TickNumber,
+				Timestamp: time.Now(),
+				Type:      "loot",
+				Message:   FormatCombatLog("You see weapons among the remains..."),
+			})
+		}
+	}
+
+	// Log weapon availability to players
+	for _, participant := range csm.combat.Participants {
+		if participant.IsPlayer && participant.IsAlive {
+			csm.combat.AddLogEntry(CombatLogEntry{
+				Tick:      csm.combat.TickNumber,
+				Timestamp: time.Now(),
+				Type:      "loot",
+				TargetID:  participant.ID,
+				Message:   FormatCombatLog("Victory! Use 'pickup' to claim your weapon from the fallen!"),
+			})
+		}
+	}
+}
+
+// advanceTurn moves to the next actor's turn
+func (csm *CombatStateMachine) advanceTurn() {
+	order := csm.combat.GetTurnOrder()
+	if len(order) == 0 {
+		return
+	}
+
+	// Move to next alive actor
+	startIdx := csm.currentActorIdx
+	for {
+		csm.currentActorIdx = (csm.currentActorIdx + 1) % len(order)
+		if csm.currentActorIdx == 0 {
+			// Completed a full round
+			csm.currentTurn++
+		}
+
+		actor := order[csm.currentActorIdx]
+		if actor.IsAlive && actor.CanAct() {
+			csm.awaitingInput[actor.ID] = true
+			csm.inputDeadline = time.Now().Add(csm.inputWindow)
+			csm.combat.TickCountdown = float64(csm.inputWindow) / float64(time.Second)
+			return
+		}
+
+		// Wrapped around, no one can act
+		if csm.currentActorIdx == startIdx {
+			csm.checkEndCondition()
+			return
+		}
+	}
+}
+
+// SubmitAction allows a participant to submit their action
+func (csm *CombatStateMachine) SubmitAction(participantID int, action *ActionDefinition, target *Participant) bool {
+	// Check if this participant can act
+	if !csm.awaitingInput[participantID] {
+		return false
+	}
+
+	// Find the participant
+	source := csm.combat.GetParticipantByID(participantID)
+	if source == nil {
+		return false
+	}
+
+	// Create queued action
+	qa := csm.combat.ActionQueue.Queue(action, source, target, csm.combat.TickNumber+action.TickCost)
+	csm.selectedActions[participantID] = qa
+
+	// Clear input awaiting
+	delete(csm.awaitingInput, participantID)
+
+	// Log the selection
+	csm.combat.AddLogEntry(CombatLogEntry{
+		Tick:      csm.combat.TickNumber,
+		Timestamp: time.Now(),
+		SourceID:  source.ID,
+		TargetID:  target.ID,
+		Type:      "info",
+		Message:   FormatCombatLog("%s prepares %s", source.Name, action.Name),
+	})
+
+	return true
+}
+
+// GetCurrentActor returns the participant whose turn it is
+func (csm *CombatStateMachine) GetCurrentActor() *Participant {
+	order := csm.combat.GetTurnOrder()
+	if len(order) == 0 || csm.currentActorIdx >= len(order) {
+		return nil
+	}
+	return order[csm.currentActorIdx]
+}
+
+// GetInputDeadline returns when the input window closes
+func (csm *CombatStateMachine) GetInputDeadline() time.Time {
+	return csm.inputDeadline
+}
+
+// IsAwaitingInput returns true if a participant needs to input an action
+func (csm *CombatStateMachine) IsAwaitingInput(participantID int) bool {
+	return csm.awaitingInput[participantID]
+}
+
+// GetTickCountdown returns seconds until next tick
+func (csm *CombatStateMachine) GetTickCountdown() float64 {
+	remaining := time.Until(csm.inputDeadline).Seconds()
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}

--- a/herbst/combat/state_machine_test.go
+++ b/herbst/combat/state_machine_test.go
@@ -1,0 +1,299 @@
+package combat
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestCombatStateMachine_TransitionTo(t *testing.T) {
+	combat := &Combat{
+		ID:           1,
+		Participants: []*Participant{},
+		State:        StateIdle,
+	}
+	
+	csm := NewCombatStateMachine(combat, nil, nil)
+	
+	// Test state transition
+	enteredInit := false
+	csm.SetOnStateEnter(StateInit, func(c *Combat) {
+		enteredInit = true
+	})
+	
+	csm.TransitionTo(StateInit)
+	
+	if combat.State != StateInit {
+		t.Errorf("Expected state %s, got %s", StateInit, combat.State)
+	}
+	
+	if !enteredInit {
+		t.Error("State enter callback should have fired")
+	}
+}
+
+func TestCombatStateMachine_Start(t *testing.T) {
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, IsAlive: true, HP: 100, MaxHP: 100, Dexterity: 15},
+		{ID: 2, Name: "Goblin", IsNPC: true, Team: 1, IsAlive: true, HP: 30, MaxHP: 30, Dexterity: 10},
+	}
+	
+	combat := &Combat{
+		ID:           1,
+		Participants: participants,
+		State:        StateIdle,
+		ActionQueue:  NewActionQueue(),
+		Effects:      NewEffectRegistry(),
+	}
+	
+	tm := NewTickManager()
+	cm := NewCombatManager()
+	csm := NewCombatStateMachine(combat, cm, tm)
+	
+	ctx := context.Background()
+	csm.Start(ctx)
+	
+	// Should have transitioned to Active
+	if combat.State != StateActive {
+		t.Errorf("Expected state %s, got %s", StateActive, combat.State)
+	}
+	
+	// Should have rolled initiative
+	if participants[0].Initiative == 0 {
+		t.Error("Participant 0 should have rolled initiative")
+	}
+	
+	if participants[1].Initiative == 0 {
+		t.Error("Participant 1 should have rolled initiative")
+	}
+	
+	// Stop to clean up
+	csm.Stop()
+}
+
+func TestCombatStateMachine_SubmitAction(t *testing.T) {
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, IsAlive: true, HP: 100, MaxHP: 100, Dexterity: 15},
+		{ID: 2, Name: "Goblin", IsNPC: true, Team: 1, IsAlive: true, HP: 30, MaxHP: 30, Dexterity: 10},
+	}
+	
+	combat := &Combat{
+		ID:           1,
+		Participants: participants,
+		State:        StateActive,
+		ActionQueue:  NewActionQueue(),
+		Effects:      NewEffectRegistry(),
+	}
+	
+	csm := NewCombatStateMachine(combat, nil, nil)
+	csm.currentActorIdx = 0
+	csm.awaitingInput[1] = true
+	
+	attack, _ := GetActionDefinition("attack")
+	target := participants[1] // Goblin
+	
+	success := csm.SubmitAction(1, attack, target)
+	
+	if !success {
+		t.Error("SubmitAction should succeed")
+	}
+	
+	// Should have cleared awaiting input
+	if csm.awaitingInput[1] {
+		t.Error("Should have cleared awaiting input after action submission")
+	}
+	
+	// Action should be in selected actions
+	if csm.selectedActions[1] == nil {
+		t.Error("Action should be stored in selectedActions")
+	}
+}
+
+func TestCombatStateMachine_GetCurrentActor(t *testing.T) {
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, Initiative: 25, IsAlive: true, HP: 100},
+		{ID: 2, Name: "Goblin", IsNPC: true, Team: 1, Initiative: 15, IsAlive: true, HP: 30},
+	}
+	
+	combat := &Combat{
+		ID:           1,
+		Participants: participants,
+		ActionQueue:  NewActionQueue(),
+		Effects:      NewEffectRegistry(),
+	}
+	
+	csm := NewCombatStateMachine(combat, nil, nil)
+	
+	// First actor should be Hero (higher initiative)
+	csm.currentActorIdx = 0
+	actor := csm.GetCurrentActor()
+	
+	if actor == nil || actor.ID != 1 {
+		t.Errorf("Expected Hero (ID 1), got %v", actor)
+	}
+	
+	// Second actor should be Goblin
+	csm.currentActorIdx = 1
+	actor = csm.GetCurrentActor()
+	
+	if actor == nil || actor.ID != 2 {
+		t.Errorf("Expected Goblin (ID 2), got %v", actor)
+	}
+}
+
+func TestCombatStateMachine_CheckEndCondition(t *testing.T) {
+	t.Run("enemies defeated", func(t *testing.T) {
+		participants := []*Participant{
+			{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, IsAlive: true, HP: 100},
+			{ID: 2, Name: "Goblin", IsNPC: true, Team: 1, IsAlive: false, HP: 0},
+		}
+		
+		combat := &Combat{
+			ID:           1,
+			Participants: participants,
+			State:        StateActive,
+			ActionQueue:  NewActionQueue(),
+			Effects:      NewEffectRegistry(),
+		}
+		
+		csm := NewCombatStateMachine(combat, nil, nil)
+		result := csm.checkEndCondition()
+		
+		if !result {
+			t.Error("Should detect enemies defeated")
+		}
+		
+		if combat.State != StateEnded {
+			t.Errorf("Combat should be ended, got %s", combat.State)
+		}
+	})
+	
+	t.Run("players defeated", func(t *testing.T) {
+		participants := []*Participant{
+			{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, IsAlive: false, HP: 0},
+			{ID: 2, Name: "Goblin", IsNPC: true, Team: 1, IsAlive: true, HP: 30},
+		}
+		
+		combat := &Combat{
+			ID:           1,
+			Participants: participants,
+			State:        StateActive,
+			ActionQueue:  NewActionQueue(),
+			Effects:      NewEffectRegistry(),
+		}
+		
+		csm := NewCombatStateMachine(combat, nil, nil)
+		result := csm.checkEndCondition()
+		
+		if !result {
+			t.Error("Should detect players defeated")
+		}
+		
+		if combat.State != StateEnded {
+			t.Errorf("Combat should be ended, got %s", combat.State)
+		}
+	})
+	
+	t.Run("combat continues", func(t *testing.T) {
+		participants := []*Participant{
+			{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, IsAlive: true, HP: 100},
+			{ID: 2, Name: "Goblin", IsNPC: true, Team: 1, IsAlive: true, HP: 30},
+		}
+		
+		combat := &Combat{
+			ID:           1,
+			Participants: participants,
+			State:        StateActive,
+			ActionQueue:  NewActionQueue(),
+			Effects:      NewEffectRegistry(),
+		}
+		
+		csm := NewCombatStateMachine(combat, nil, nil)
+		result := csm.checkEndCondition()
+		
+		if result {
+			t.Error("Combat should continue")
+		}
+	})
+}
+
+func TestCombatStateMachine_ExecuteAction(t *testing.T) {
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, IsAlive: true, HP: 100, MaxHP: 100},
+		{ID: 2, Name: "Goblin", IsNPC: true, Team: 1, IsAlive: true, HP: 30, MaxHP: 30},
+	}
+	
+	combat := &Combat{
+		ID:           1,
+		Participants: participants,
+		ActionQueue:  NewActionQueue(),
+		Effects:      NewEffectRegistry(),
+		Log:          []CombatLogEntry{},
+	}
+	
+	csm := NewCombatStateMachine(combat, nil, nil)
+	
+	attack, _ := GetActionDefinition("attack")
+	qa := &QueuedAction{
+		Action: attack,
+		Source: participants[0],
+		Target: participants[1],
+	}
+	
+	csm.executeAction(qa)
+	
+	// Goblin should have taken damage
+	if participants[1].HP >= 30 {
+		t.Errorf("Goblin should have taken damage, HP: %d", participants[1].HP)
+	}
+	
+	// Should have logged the action
+	if len(combat.Log) == 0 {
+		t.Error("Should have logged the action")
+	}
+}
+
+func TestCombatStateMachine_GetTickCountdown(t *testing.T) {
+	combat := &Combat{
+		ID:          1,
+		ActionQueue: NewActionQueue(),
+		Effects:     NewEffectRegistry(),
+	}
+	
+	csm := NewCombatStateMachine(combat, nil, nil)
+	csm.inputWindow = TickDuration
+	csm.inputDeadline = time.Now().Add(TickDuration)
+	
+	countdown := csm.GetTickCountdown()
+	
+	// Countdown should be roughly 1.5 seconds
+	if countdown < 1.0 || countdown > 1.6 {
+		t.Errorf("Expected countdown ~1.5s, got %f", countdown)
+	}
+}
+
+func TestCombatStateMachine_AwaitInput(t *testing.T) {
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, IsAlive: true, HP: 100, Initiative: 25},
+	}
+	
+	combat := &Combat{
+		ID:           1,
+		Participants: participants,
+		ActionQueue:  NewActionQueue(),
+		Effects:      NewEffectRegistry(),
+	}
+	
+	csm := NewCombatStateMachine(combat, nil, nil)
+	
+	// Set up input waiting
+	csm.awaitingInput[1] = true
+	
+	if !csm.IsAwaitingInput(1) {
+		t.Error("Should be awaiting input for participant 1")
+	}
+	
+	if csm.IsAwaitingInput(2) {
+		t.Error("Should not be awaiting input for participant 2")
+	}
+}

--- a/herbst/combat/tick_test.go
+++ b/herbst/combat/tick_test.go
@@ -1,0 +1,74 @@
+package combat
+
+import (
+	"testing"
+)
+
+func TestTickManager_StartStop(t *testing.T) {
+	tm := NewTickManager()
+	
+	if tm.IsRunning() {
+		t.Error("TickManager should not be running initially")
+	}
+	
+	ctx := t.Context()
+	tm.Start(ctx)
+	
+	if !tm.IsRunning() {
+		t.Error("TickManager should be running after Start()")
+	}
+	
+	tm.Stop()
+	
+	if tm.IsRunning() {
+		t.Error("TickManager should not be running after Stop()")
+	}
+}
+
+func TestTickManager_Subscribe(t *testing.T) {
+	tm := NewTickManager()
+	ctx := t.Context()
+	tm.Start(ctx)
+	defer tm.Stop()
+	
+	ch := tm.Subscribe(1)
+	if ch == nil {
+		t.Error("Subscribe should return a channel")
+	}
+	
+	// Check subscriber is registered
+	tm.mu.RLock()
+	_, exists := tm.subscribers[1]
+	tm.mu.RUnlock()
+	
+	if !exists {
+		t.Error("Combat should be subscribed")
+	}
+}
+
+func TestTickManager_Unsubscribe(t *testing.T) {
+	tm := NewTickManager()
+	ctx := t.Context()
+	tm.Start(ctx)
+	defer tm.Stop()
+	
+	_ = tm.Subscribe(1)
+	tm.Unsubscribe(1)
+	
+	tm.mu.RLock()
+	_, exists := tm.subscribers[1]
+	tm.mu.RUnlock()
+	
+	if exists {
+		t.Error("Combat should be unsubscribed")
+	}
+}
+
+func TestTickManager_GetCurrentTick(t *testing.T) {
+	tm := NewTickManager()
+	
+	// Initial tick should be 0
+	if tick := tm.GetCurrentTick(); tick != 0 {
+		t.Errorf("Expected initial tick to be 0, got %d", tick)
+	}
+}

--- a/herbst/combat/ui.go
+++ b/herbst/combat/ui.go
@@ -1,0 +1,720 @@
+package combat
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// UI styles for combat display
+var (
+	// Colors
+	red       = lipgloss.Color("196")
+	green     = lipgloss.Color("46")
+	yellow    = lipgloss.Color("226")
+	blue      = lipgloss.Color("75")
+	purple    = lipgloss.Color("141")
+	white     = lipgloss.Color("15")
+	gray      = lipgloss.Color("8")
+	orange    = lipgloss.Color("208")
+	cyan      = lipgloss.Color("51")
+	darkRed   = lipgloss.Color("88")
+	darkBlue  = lipgloss.Color("18")
+	
+	// Box styles
+	borderStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(purple)
+	
+	titleStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(green).
+			Background(darkBlue).
+			Padding(0, 1)
+	
+	headerStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(blue).
+			Padding(0, 1)
+	
+	// HP bar styles
+	hpBarStyle = lipgloss.NewStyle().Foreground(red)
+	manaBarStyle = lipgloss.NewStyle().Foreground(blue)
+	staminaBarStyle = lipgloss.NewStyle().Foreground(yellow)
+	
+	// Combat log styles
+	damageStyle = lipgloss.NewStyle().Foreground(red)
+	healStyle = lipgloss.NewStyle().Foreground(green)
+	infoStyle = lipgloss.NewStyle().Foreground(cyan)
+	systemStyle = lipgloss.NewStyle().Foreground(yellow)
+	
+	// Action bar styles
+	actionReadyStyle = lipgloss.NewStyle().
+				Foreground(white).
+				Background(darkBlue).
+				Padding(0, 2).
+				Bold(true)
+	
+	actionCooldownStyle = lipgloss.NewStyle().
+				Foreground(gray).
+				Background(darkBlue).
+				Padding(0, 2)
+	
+	// Tick timer styles
+	tickActiveStyle = lipgloss.NewStyle().
+				Foreground(green).
+				Bold(true)
+	
+	tickWarningStyle = lipgloss.NewStyle().
+				Foreground(yellow).
+				Bold(true)
+	
+	tickCriticalStyle = lipgloss.NewStyle().
+				Foreground(red).
+				Bold(true)
+)
+
+// CombatUI renders the combat screen
+type CombatUI struct {
+	width  int
+	height int
+}
+
+// NewCombatUI creates a new combat UI renderer
+func NewCombatUI(width, height int) *CombatUI {
+	return &CombatUI{
+		width:  width,
+		height: height,
+	}
+}
+
+// Render generates the full combat screen
+func (ui *CombatUI) Render(combat *Combat, stateMachine *CombatStateMachine, inputManager *InputManager, playerID int) string {
+	var b strings.Builder
+	
+	// Title bar
+	b.WriteString(ui.renderTitleBar(combat))
+	b.WriteString("\n")
+	
+	// Enemy HP bars
+	b.WriteString(ui.renderEnemyHP(combat))
+	b.WriteString("\n")
+	
+	// Turn order
+	b.WriteString(ui.renderTurnOrder(combat))
+	b.WriteString("\n")
+	
+	// Combat log
+	b.WriteString(ui.renderCombatLog(combat, 5))
+	b.WriteString("\n")
+	
+	// Player status (HP/Mana/Stamina bars)
+	b.WriteString(ui.renderPlayerStatus(combat, playerID))
+	b.WriteString("\n")
+	
+	// Tick counter
+	b.WriteString(ui.renderTickCounter(combat, stateMachine, inputManager, playerID))
+	b.WriteString("\n")
+	
+	// Status effects
+	b.WriteString(ui.renderStatusEffects(combat, playerID))
+	b.WriteString("\n")
+	
+	// Action bar (talents 1-4)
+	b.WriteString(ui.renderActionBar(combat, playerID, inputManager))
+	b.WriteString("\n")
+	
+	// Input prompt
+	b.WriteString(ui.renderInputPrompt(combat, stateMachine, playerID))
+	
+	return b.String()
+}
+
+// renderTitleBar renders the combat title
+func (ui *CombatUI) renderTitleBar(combat *Combat) string {
+	stateStr := string(combat.State)
+	if combat.State == StateActive {
+		roundNum := 1
+		if len(combat.Participants) > 0 {
+			roundNum = combat.TickNumber/len(combat.Participants) + 1
+		}
+		stateStr = fmt.Sprintf("Round %d", roundNum)
+	}
+	
+	title := titleStyle.Render(fmt.Sprintf("⚔️  COMBAT - %s  ⚔️", stateStr))
+	return titleStyle.Render(title)
+}
+
+// renderEnemyHP renders HP bars for all enemies
+func (ui *CombatUI) renderEnemyHP(combat *Combat) string {
+	var b strings.Builder
+	
+	b.WriteString(headerStyle.Render("Enemies:"))
+	b.WriteString("\n")
+	
+	enemies := combat.GetAliveByTeam(1) // Team 1 = enemies
+	
+	if len(enemies) == 0 {
+		b.WriteString(infoStyle.Render("  No enemies remaining"))
+		return b.String()
+	}
+	
+	for _, enemy := range enemies {
+		hpBar := ui.renderHPBar(enemy.HP, enemy.MaxHP, 20)
+		status := ""
+		if !enemy.IsAlive {
+			status = " [DEAD]"
+		}
+		
+		line := fmt.Sprintf("  %s %s %d/%d%s",
+			enemy.Name,
+			hpBar,
+			enemy.HP,
+			enemy.MaxHP,
+			status,
+		)
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	
+	return b.String()
+}
+
+// renderHPBar creates a text-based HP progress bar
+func (ui *CombatUI) renderHPBar(current, max, width int) string {
+	if max <= 0 {
+		max = 1
+	}
+	if current < 0 {
+		current = 0
+	}
+	if current > max {
+		current = max
+	}
+	
+	percent := float64(current) / float64(max)
+	filled := int(percent * float64(width))
+	empty := width - filled
+	
+	var color lipgloss.Color
+	if percent > 0.6 {
+		color = green
+	} else if percent > 0.3 {
+		color = yellow
+	} else {
+		color = red
+	}
+	
+	filledStr := lipgloss.NewStyle().Foreground(color).Render(strings.Repeat("█", filled))
+	emptyStr := lipgloss.NewStyle().Foreground(gray).Render(strings.Repeat("░", empty))
+	
+	return fmt.Sprintf("[%s%s]", filledStr, emptyStr)
+}
+
+// renderTurnOrder renders the turn order display
+func (ui *CombatUI) renderTurnOrder(combat *Combat) string {
+	var b strings.Builder
+	
+	b.WriteString(headerStyle.Render("Turn Order:"))
+	b.WriteString("\n")
+	
+	order := combat.GetTurnOrder()
+	if len(order) == 0 {
+		return b.String()
+	}
+	
+	for i, p := range order {
+		indicator := "  "
+		if i == 0 {
+			indicator = "▶ "
+		}
+		
+		teamLabel := "Ally"
+		color := green
+		if p.Team == 1 {
+			teamLabel = "Enemy"
+			color = red
+		}
+		
+		status := ""
+		if !p.IsAlive {
+			status = " ✗"
+		}
+		
+		nameStyle := lipgloss.NewStyle().Foreground(color)
+		line := fmt.Sprintf("%s%s%s (%d) - Init: %d%s",
+			indicator,
+			nameStyle.Render(p.Name),
+			teamLabel,
+			p.TurnPosition,
+			p.Initiative,
+			status,
+		)
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	
+	return b.String()
+}
+
+// renderCombatLog renders recent combat log entries
+func (ui *CombatUI) renderCombatLog(combat *Combat, maxEntries int) string {
+	var b strings.Builder
+	
+	b.WriteString(headerStyle.Render("Combat Log:"))
+	b.WriteString("\n")
+	
+	// Get last N entries
+	start := len(combat.Log) - maxEntries
+	if start < 0 {
+		start = 0
+	}
+	
+	entries := combat.Log[start:]
+	
+	for _, entry := range entries {
+		var line string
+		
+		switch entry.Type {
+		case "damage":
+			line = damageStyle.Render(fmt.Sprintf("  💢 %s", entry.Message))
+		case "heal":
+			line = healStyle.Render(fmt.Sprintf("  💚 %s", entry.Message))
+		case "system":
+			line = systemStyle.Render(fmt.Sprintf("  ⚙️ %s", entry.Message))
+		case "info":
+			line = infoStyle.Render(fmt.Sprintf("  ℹ️ %s", entry.Message))
+		default:
+			line = fmt.Sprintf("  %s", entry.Message)
+		}
+		
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	
+	return b.String()
+}
+
+// renderPlayerStatus renders the player's HP/Mana/Stamina bars
+func (ui *CombatUI) renderPlayerStatus(combat *Combat, playerID int) string {
+	player := combat.GetParticipantByID(playerID)
+	if player == nil {
+		return ""
+	}
+	
+	var b strings.Builder
+	
+	b.WriteString(headerStyle.Render(fmt.Sprintf("%s's Status:", player.Name)))
+	b.WriteString("\n")
+	
+	// HP Bar
+	hpBar := ui.renderHPBar(player.HP, player.MaxHP, 15)
+	b.WriteString(fmt.Sprintf("  ❤️ HP:    %s %d/%d\n", hpBar, player.HP, player.MaxHP))
+	
+	// Mana Bar
+	manaPercent := float64(player.Mana) / float64(player.MaxMana)
+	manaFilled := int(manaPercent * 15)
+	manaBar := lipgloss.NewStyle().Foreground(blue).Render(strings.Repeat("✨", manaFilled)) +
+		lipgloss.NewStyle().Foreground(gray).Render(strings.Repeat("○", 15-manaFilled))
+	b.WriteString(fmt.Sprintf("  ✨ Mana:  [%s] %d/%d\n", manaBar, player.Mana, player.MaxMana))
+	
+	// Stamina Bar
+	staminaPercent := float64(player.Stamina) / float64(player.MaxStamina)
+	staminaFilled := int(staminaPercent * 15)
+	staminaBar := lipgloss.NewStyle().Foreground(yellow).Render(strings.Repeat("💪", staminaFilled)) +
+		lipgloss.NewStyle().Foreground(gray).Render(strings.Repeat("○", 15-staminaFilled))
+	b.WriteString(fmt.Sprintf("  💪 STA:   [%s] %d/%d\n", staminaBar, player.Stamina, player.MaxStamina))
+	
+	return b.String()
+}
+
+// renderTickCounter renders the tick countdown timer
+func (ui *CombatUI) renderTickCounter(combat *Combat, stateMachine *CombatStateMachine, inputManager *InputManager, playerID int) string {
+	remaining := inputManager.GetTimeRemaining(playerID)
+	
+	var style lipgloss.Style
+	remainingFloat := 0.0
+	fmt.Sscanf(remaining, "%f", &remainingFloat)
+	
+	if remainingFloat > 1.0 {
+		style = tickActiveStyle
+	} else if remainingFloat > 0.5 {
+		style = tickWarningStyle
+	} else {
+		style = tickCriticalStyle
+	}
+	
+	tickStr := fmt.Sprintf("⏱️ Tick %d | Time: %ss", combat.TickNumber, remaining)
+	
+	// Show current actor
+	currentActor := stateMachine.GetCurrentActor()
+	if currentActor != nil {
+		actorStyle := lipgloss.NewStyle().Foreground(cyan).Bold(true)
+		tickStr += fmt.Sprintf(" | %s's turn", actorStyle.Render(currentActor.Name))
+	}
+	
+	return style.Render(tickStr)
+}
+
+// renderStatusEffects renders active status effects for a participant
+func (ui *CombatUI) renderStatusEffects(combat *Combat, playerID int) string {
+	var b strings.Builder
+
+	// Get active effects from the registry
+	effects := combat.Effects.GetEffectsForParticipant(playerID)
+	if len(effects) == 0 {
+		return ""
+	}
+
+	b.WriteString(headerStyle.Render("Status Effects:"))
+	b.WriteString("\n")
+
+	for _, effect := range effects {
+		var icon string
+		switch effect.Type {
+		case "buff":
+			icon = "💚"
+		case "debuff":
+			icon = "💔"
+		case "channel":
+			icon = "🔄"
+		case "charge":
+			icon = "⏳"
+		default:
+			icon = "⚪"
+		}
+
+		remaining := ""
+		if effect.TicksRemaining > 0 {
+			remaining = fmt.Sprintf(" (%d ticks)", effect.TicksRemaining)
+		}
+
+		line := fmt.Sprintf("  %s %s%s\n", icon, effect.Name, remaining)
+		b.WriteString(line)
+	}
+
+	return b.String()
+}
+
+// renderActionBar renders the action bar with talent slots
+func (ui *CombatUI) renderActionBar(combat *Combat, playerID int, inputManager *InputManager) string {
+	var b strings.Builder
+	
+	b.WriteString(headerStyle.Render("Actions:"))
+	b.WriteString("\n")
+	
+	// Get player's talent bindings
+	bindings := inputManager.GetTalentBindings(playerID)
+	
+	// Default to basic actions if no bindings
+	if len(bindings) == 0 {
+		bindings = map[int]string{1: "attack", 2: "defend", 3: "item", 4: "wait"}
+	}
+	
+	// Render action slots
+	slots := []int{1, 2, 3, 4}
+	
+	for _, slot := range slots {
+		actionID := bindings[slot]
+		action, found := GetActionDefinition(actionID)
+		if !found {
+			action = BasicActions["attack"] // Fallback
+		}
+		
+		// Check if awaiting input
+		awaiting := inputManager.IsAwaitingInput(playerID)
+		
+		var slotStr string
+		if awaiting {
+			slotStr = actionReadyStyle.Render(fmt.Sprintf("[%d] %s", slot, action.Name))
+		} else {
+			slotStr = actionCooldownStyle.Render(fmt.Sprintf("[%d] %s", slot, action.Name))
+		}
+		
+		b.WriteString(fmt.Sprintf("  %s", slotStr))
+		
+		// Add tick cost info
+		if action.TickCost > 0 {
+			b.WriteString(fmt.Sprintf(" (%d tick)", action.TickCost))
+		}
+		
+		// Add resource costs
+		if action.ManaCost > 0 {
+			b.WriteString(fmt.Sprintf(" -%d mana", action.ManaCost))
+		}
+		if action.StaminaCost > 0 {
+			b.WriteString(fmt.Sprintf(" -%d sta", action.StaminaCost))
+		}
+		
+		// Add type indicator
+		switch action.Type {
+		case ActionCharge:
+			b.WriteString(" ⏳")
+		case ActionChannel:
+			b.WriteString(" 🔄")
+		}
+		
+		b.WriteString("\n")
+	}
+	
+	return b.String()
+}
+
+// renderInputPrompt renders the input prompt for the current actor
+func (ui *CombatUI) renderInputPrompt(combat *Combat, stateMachine *CombatStateMachine, playerID int) string {
+	player := combat.GetParticipantByID(playerID)
+	if player == nil {
+		return ""
+	}
+	
+	// Check if it's the player's turn
+	currentActor := stateMachine.GetCurrentActor()
+	if currentActor == nil || currentActor.ID != playerID {
+		return systemStyle.Render("Waiting for enemy action...")
+	}
+	
+	// Check if awaiting input
+	if !stateMachine.IsAwaitingInput(playerID) {
+		return infoStyle.Render("Processing...")
+	}
+	
+	remaining := stateMachine.GetTickCountdown()
+	
+	prompt := fmt.Sprintf(">>> Your turn! Select action [1-4] (%.1fs remaining)", remaining)
+	return tickActiveStyle.Render(prompt)
+}
+
+// RenderCompactHPBar renders a compact inline HP bar
+func RenderCompactHPBar(current, max int) string {
+	if max <= 0 {
+		max = 1
+	}
+	percent := float64(current) / float64(max)
+	
+	var color lipgloss.Color
+	if percent > 0.6 {
+		color = green
+	} else if percent > 0.3 {
+		color = yellow
+	} else {
+		color = red
+	}
+	
+	blocks := int(percent * 5)
+	if blocks > 5 {
+		blocks = 5
+	}
+	if blocks < 0 {
+		blocks = 0
+	}
+	
+	bar := lipgloss.NewStyle().Foreground(color).Render(strings.Repeat("█", blocks)) +
+		lipgloss.NewStyle().Foreground(gray).Render(strings.Repeat("░", 5-blocks))
+	
+	return fmt.Sprintf("%s %d/%d", bar, current, max)
+}
+
+// FormatTimeRemaining formats time remaining for display
+func FormatTimeRemaining(d time.Duration) string {
+	seconds := d.Seconds()
+	if seconds < 0 {
+		return "0.0"
+	}
+	return fmt.Sprintf("%.1f", seconds)
+}
+
+// VictoryScreenStyle for victory display
+var (
+	victoryTitleStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(yellow).
+				Background(darkRed).
+				Padding(1, 4).
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(yellow)
+
+	victoryBoxStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(green).
+				Padding(1, 2)
+
+	lootHeaderStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(yellow).
+				MarginTop(1)
+
+	lootItemStyle = lipgloss.NewStyle().
+				Foreground(white)
+
+	xpStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(green)
+
+	skillUpStyle = lipgloss.NewStyle().
+			Foreground(cyan)
+
+	defeatTitleStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(white).
+				Background(darkRed).
+				Padding(1, 4).
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(red)
+
+	defeatBoxStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(red).
+				Padding(1, 2)
+
+	consequenceStyle = lipgloss.NewStyle().
+				Foreground(yellow)
+
+	respawnStyle = lipgloss.NewStyle().
+			Foreground(cyan)
+)
+
+// RenderVictoryScreen renders the victory screen UI
+func (ui *CombatUI) RenderVictoryScreen(result *VictoryResult, width int) string {
+	var b strings.Builder
+
+	// Title
+	title := victoryTitleStyle.Render("⚔️  VICTORY!  ⚔️")
+	b.WriteString(title)
+	b.WriteString("\n\n")
+
+	// Victory message
+	b.WriteString(victoryBoxStyle.Render("All enemies have been defeated!"))
+	b.WriteString("\n\n")
+
+	// Loot section
+	if len(result.Loot) > 0 {
+		b.WriteString(lootHeaderStyle.Render("LOOT:"))
+		b.WriteString("\n")
+		for _, item := range result.Loot {
+			rarityColor := white
+			switch item.Rarity {
+			case "uncommon":
+				rarityColor = green
+			case "rare":
+				rarityColor = purple
+			case "legendary":
+				rarityColor = yellow
+			}
+
+			itemStyle := lipgloss.NewStyle().Foreground(rarityColor)
+			b.WriteString(fmt.Sprintf("  • %s", itemStyle.Render(item.Name)))
+			if item.Quantity > 1 {
+				b.WriteString(fmt.Sprintf(" x%d", item.Quantity))
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	// Coins
+	if result.Coins > 0 {
+		b.WriteString(xpStyle.Render(fmt.Sprintf("  💰 %d coins", result.Coins)))
+		b.WriteString("\n")
+	}
+
+	// XP
+	if result.XP > 0 {
+		b.WriteString(xpStyle.Render(fmt.Sprintf("  ⭐ %d XP", result.XP)))
+		b.WriteString("\n\n")
+	}
+
+	// Weapon drops
+	if len(result.WeaponDrops) > 0 {
+		b.WriteString(lootHeaderStyle.Render("WEAPONS:"))
+		b.WriteString("\n")
+		for _, drop := range result.WeaponDrops {
+			classText := ""
+			if drop.ClassRestriction != "" {
+				classText = fmt.Sprintf(" (%s only)", drop.ClassRestriction)
+			}
+			b.WriteString(fmt.Sprintf("  ⚔️  %s%s\n", drop.Name, classText))
+			b.WriteString(fmt.Sprintf("      Damage: %d-%d\n", drop.MinDamage, drop.MaxDamage))
+		}
+		b.WriteString("\n")
+	}
+
+	// Skill ups
+	if len(result.SkillUps) > 0 {
+		b.WriteString(skillUpStyle.Render("SKILL UP:"))
+		b.WriteString("\n")
+		for _, su := range result.SkillUps {
+			b.WriteString(fmt.Sprintf("  • %s +%d\n", su.SkillName, su.Amount))
+		}
+	}
+
+	return b.String()
+}
+
+// RenderDefeatScreen renders the defeat screen UI
+func (ui *CombatUI) RenderDefeatScreen(result *DefeatResult, enemyName string, width int) string {
+	var b strings.Builder
+
+	// Title
+	title := defeatTitleStyle.Render("💀  DEFEAT  💀")
+	b.WriteString(title)
+	b.WriteString("\n\n")
+
+	// Defeat message
+	defeatMsg := fmt.Sprintf("You have fallen to %s...", enemyName)
+	b.WriteString(defeatBoxStyle.Render(defeatMsg))
+	b.WriteString("\n\n")
+
+	// Consequences
+	b.WriteString(consequenceStyle.Render("CONSEQUENCES:"))
+	b.WriteString("\n")
+	for _, c := range result.Consequences {
+		b.WriteString(fmt.Sprintf("  • %s\n", c))
+	}
+	b.WriteString("\n")
+
+	// Respawn info
+	b.WriteString(respawnStyle.Render("You will respawn at the last save point."))
+	b.WriteString("\n")
+
+	// Corpse timer
+	if !result.CorpseExpiry.IsZero() {
+		timeRemaining := time.Until(result.CorpseExpiry)
+		if timeRemaining > 0 {
+			b.WriteString(respawnStyle.Render(fmt.Sprintf("Equipment reclaimable for: %.0f seconds", timeRemaining.Seconds())))
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}
+
+// RenderCombatEnd renders either victory or defeat screen based on result
+func RenderCombatEnd(combat *Combat, playerID, respawnRoom int, width int) string {
+	ui := NewCombatUI(width, 20)
+
+	// Check if player won or lost
+	if combat.AllEnemiesDefeated() {
+		result := combat.HandleVictory()
+		return ui.RenderVictoryScreen(result, width)
+	}
+
+	if combat.AllPlayersDefeated() {
+		// Find the enemy that delivered the killing blow
+		enemyName := "an enemy"
+		for _, p := range combat.Participants {
+			if p.IsNPC && p.IsAlive && p.Team == 1 {
+				enemyName = p.Name
+				break
+			}
+		}
+
+		result := combat.HandleDefeat(respawnRoom)
+		return ui.RenderDefeatScreen(result, enemyName, width)
+	}
+
+	// Combat still ongoing
+	return ""
+}
+

--- a/herbst/combat/ui_result_test.go
+++ b/herbst/combat/ui_result_test.go
@@ -1,0 +1,296 @@
+package combat
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRenderVictoryScreen_Basic(t *testing.T) {
+	ui := NewCombatUI(80, 20)
+
+	result := &VictoryResult{
+		Loot: []LootItem{
+			{ID: 1, Name: "Rusty Pipe", Description: "A bent pipe", Quantity: 1, Rarity: "common"},
+		},
+		Coins:       23,
+		XP:          150,
+		VictoryTime: time.Now(),
+	}
+
+	output := ui.RenderVictoryScreen(result, 80)
+
+	// Check for victory elements
+	if !strings.Contains(output, "VICTORY") {
+		t.Error("Expected victory title in output")
+	}
+
+	if !strings.Contains(output, "Rusty Pipe") {
+		t.Error("Expected loot item in output")
+	}
+
+	if !strings.Contains(output, "23") {
+		t.Error("Expected coin amount in output")
+	}
+
+	if !strings.Contains(output, "150") {
+		t.Error("Expected XP amount in output")
+	}
+}
+
+func TestRenderVictoryScreen_WithWeapons(t *testing.T) {
+	ui := NewCombatUI(80, 20)
+
+	result := &VictoryResult{
+		Loot:        []LootItem{},
+		XP:          200,
+		VictoryTime: time.Now(),
+		WeaponDrops: []WeaponDrop{
+			{Name: "Scrap Machete", WeaponType: "sword", ClassRestriction: "warrior", MinDamage: 4, MaxDamage: 8, Guaranteed: true},
+		},
+	}
+
+	output := ui.RenderVictoryScreen(result, 80)
+
+	// Check for weapon section
+	if !strings.Contains(output, "WEAPONS") {
+		t.Error("Expected weapons section in output")
+	}
+
+	if !strings.Contains(output, "Scrap Machete") {
+		t.Error("Expected weapon name in output")
+	}
+
+	if !strings.Contains(output, "warrior") {
+		t.Error("Expected class restriction in output")
+	}
+}
+
+func TestRenderVictoryScreen_WithSkillUps(t *testing.T) {
+	ui := NewCombatUI(80, 20)
+
+	result := &VictoryResult{
+		XP:          100,
+		VictoryTime: time.Now(),
+		SkillUps: []SkillUp{
+			{SkillName: "blades", Amount: 2, NewLevel: 47},
+			{SkillName: "brawling", Amount: 1, NewLevel: 15},
+		},
+	}
+
+	output := ui.RenderVictoryScreen(result, 80)
+
+	// Check for skill up section
+	if !strings.Contains(output, "SKILL UP") {
+		t.Error("Expected skill up section in output")
+	}
+
+	if !strings.Contains(output, "blades") {
+		t.Error("Expected blades skill in output")
+	}
+
+	if !strings.Contains(output, "brawling") {
+		t.Error("Expected brawling skill in output")
+	}
+}
+
+func TestRenderVictoryScreen_Rarity(t *testing.T) {
+	ui := NewCombatUI(80, 20)
+
+	result := &VictoryResult{
+		Loot: []LootItem{
+			{ID: 1, Name: "Common Item", Rarity: "common"},
+			{ID: 2, Name: "Uncommon Item", Rarity: "uncommon"},
+			{ID: 3, Name: "Rare Item", Rarity: "rare"},
+			{ID: 4, Name: "Legendary Item", Rarity: "legendary"},
+		},
+		XP:          100,
+		VictoryTime: time.Now(),
+	}
+
+	output := ui.RenderVictoryScreen(result, 80)
+
+	// All items should appear
+	if !strings.Contains(output, "Common Item") {
+		t.Error("Expected common item in output")
+	}
+
+	if !strings.Contains(output, "Uncommon Item") {
+		t.Error("Expected uncommon item in output")
+	}
+
+	if !strings.Contains(output, "Rare Item") {
+		t.Error("Expected rare item in output")
+	}
+
+	if !strings.Contains(output, "Legendary Item") {
+		t.Error("Expected legendary item in output")
+	}
+}
+
+func TestRenderDefeatScreen_Basic(t *testing.T) {
+	ui := NewCombatUI(80, 20)
+
+	result := &DefeatResult{
+		XPLost:         10,
+		RespawnPoint:   1,
+		CorpseLocation:  5,
+		CorpseExpiry:   time.Now().Add(5 * time.Minute),
+		Consequences: []string{
+			"Lose 10 XP (10% of current level progress)",
+			"Your equipment has been left in the combat area",
+		},
+		DefeatTime: time.Now(),
+	}
+
+	output := ui.RenderDefeatScreen(result, "Old Scrap", 80)
+
+	// Check for defeat elements
+	if !strings.Contains(output, "DEFEAT") {
+		t.Error("Expected defeat title in output")
+	}
+
+	if !strings.Contains(output, "Old Scrap") {
+		t.Error("Expected enemy name in output")
+	}
+
+	if !strings.Contains(output, "CONSEQUENCES") {
+		t.Error("Expected consequences section in output")
+	}
+
+	if !strings.Contains(output, "equipment") {
+		t.Error("Expected equipment consequence in output")
+	}
+}
+
+func TestRenderDefeatScreen_Consequences(t *testing.T) {
+	ui := NewCombatUI(80, 20)
+
+	result := &DefeatResult{
+		XPLost:         50,
+		RespawnPoint:    1,
+		CorpseLocation:  10,
+		CorpseExpiry:    time.Now().Add(5 * time.Minute),
+		Consequences:    []string{"Lose 50 XP", "Drop 1 item"},
+		DefeatTime:      time.Now(),
+	}
+
+	output := ui.RenderDefeatScreen(result, "Boss", 80)
+
+	// All consequences should appear
+	for _, c := range result.Consequences {
+		if !strings.Contains(output, c) {
+			t.Errorf("Expected consequence '%s' in output", c)
+		}
+	}
+}
+
+func TestRenderCombatEnd_Victory(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateEnded,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsNPC: true, Team: 1, HP: 0, MaxHP: 20, Level: 1, IsAlive: false},
+		},
+		Log: []CombatLogEntry{},
+	}
+
+	output := RenderCombatEnd(combat, 1, 1, 80)
+
+	// Should show victory
+	if !strings.Contains(output, "VICTORY") {
+		t.Error("Expected victory screen when all enemies defeated")
+	}
+}
+
+func TestRenderCombatEnd_Defeat(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateEnded,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 0, MaxHP: 50, IsAlive: false},
+			{ID: 2, Name: "Boss", IsNPC: true, Team: 1, HP: 30, MaxHP: 100, Level: 10, IsAlive: true},
+		},
+		Log: []CombatLogEntry{},
+	}
+
+	output := RenderCombatEnd(combat, 1, 1, 80)
+
+	// Should show defeat
+	if !strings.Contains(output, "DEFEAT") {
+		t.Error("Expected defeat screen when all players defeated")
+	}
+
+	// Should show the enemy that delivered the killing blow
+	if !strings.Contains(output, "Boss") {
+		t.Error("Expected enemy name in defeat screen")
+	}
+}
+
+func TestRenderCombatEnd_Ongoing(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Enemy", IsNPC: true, Team: 1, HP: 20, MaxHP: 20, Level: 1, IsAlive: true},
+		},
+		Log: []CombatLogEntry{},
+	}
+
+	output := RenderCombatEnd(combat, 1, 1, 80)
+
+	// Should return empty string for ongoing combat
+	if output != "" {
+		t.Errorf("Expected empty string for ongoing combat, got: %s", output)
+	}
+}
+
+func TestVictoryResult_EmptyLoot(t *testing.T) {
+	combat := &Combat{
+		ID:    1,
+		State: StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 50, MaxHP: 50, IsAlive: true},
+			{ID: 2, Name: "Weak Enemy", IsNPC: true, Team: 1, HP: 0, MaxHP: 5, Level: 1, IsAlive: false},
+		},
+		Log: []CombatLogEntry{},
+	}
+
+	result := combat.HandleVictory()
+
+	// Should still give XP even with minimal enemies
+	if result.XP < 1 {
+		t.Error("Expected at least some XP for victory")
+	}
+
+	// Victory time should be set
+	if result.VictoryTime.IsZero() {
+		t.Error("Expected victory time to be set")
+	}
+}
+
+func TestDefeatResult_PlayerRespawn(t *testing.T) {
+	combat := &Combat{
+		ID:     1,
+		RoomID: 5,
+		State:  StateActive,
+		Participants: []*Participant{
+			{ID: 1, Name: "Player", IsPlayer: true, Team: 0, HP: 0, MaxHP: 50, IsAlive: false},
+		},
+	}
+
+	startingRoom := 1 // Foggy Gate
+	result := combat.HandleDefeat(startingRoom)
+
+	// Should use provided respawn room
+	if result.RespawnPoint != startingRoom {
+		t.Errorf("Expected respawn point %d, got %d", startingRoom, result.RespawnPoint)
+	}
+
+	// Corpse location should be combat room
+	if result.CorpseLocation != combat.RoomID {
+		t.Errorf("Expected corpse location %d, got %d", combat.RoomID, result.CorpseLocation)
+	}
+}

--- a/herbst/combat/ui_test.go
+++ b/herbst/combat/ui_test.go
@@ -1,0 +1,265 @@
+package combat
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewCombatUI(t *testing.T) {
+	ui := NewCombatUI(80, 24)
+	
+	if ui.width != 80 {
+		t.Errorf("Expected width 80, got %d", ui.width)
+	}
+	
+	if ui.height != 24 {
+		t.Errorf("Expected height 24, got %d", ui.height)
+	}
+}
+
+func TestCombatUI_RenderTitleBar(t *testing.T) {
+	ui := NewCombatUI(80, 24)
+	
+	combat := &Combat{
+		ID:           1,
+		State:        StateActive,
+		TickNumber:   5,
+		Participants: []*Participant{},
+	}
+	
+	titleBar := ui.renderTitleBar(combat)
+	
+	if !strings.Contains(titleBar, "COMBAT") {
+		t.Error("Title bar should contain 'COMBAT'")
+	}
+}
+
+func TestCombatUI_RenderEnemyHP(t *testing.T) {
+	ui := NewCombatUI(80, 24)
+	
+	combat := &Combat{
+		ID: 1,
+		Participants: []*Participant{
+			{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, HP: 100, MaxHP: 100, IsAlive: true},
+			{ID: 2, Name: "Goblin", IsNPC: true, Team: 1, HP: 30, MaxHP: 50, IsAlive: true},
+		},
+	}
+	
+	enemyHP := ui.renderEnemyHP(combat)
+	
+	if !strings.Contains(enemyHP, "Goblin") {
+		t.Error("Enemy HP should contain enemy name")
+	}
+}
+
+func TestCombatUI_RenderHPBar(t *testing.T) {
+	ui := NewCombatUI(80, 24)
+	
+	// Full HP
+	bar := ui.renderHPBar(100, 100, 10)
+	if !strings.Contains(bar, "█") {
+		t.Error("Full HP bar should contain filled blocks")
+	}
+	
+	// Half HP
+	bar = ui.renderHPBar(50, 100, 10)
+	if !strings.Contains(bar, "█") || !strings.Contains(bar, "░") {
+		t.Error("Half HP bar should contain both filled and empty blocks")
+	}
+	
+	// Low HP
+	bar = ui.renderHPBar(10, 100, 10)
+	if !strings.Contains(bar, "░") {
+		t.Error("Low HP bar should contain empty blocks")
+	}
+}
+
+func TestCombatUI_RenderTurnOrder(t *testing.T) {
+	ui := NewCombatUI(80, 24)
+	
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, Initiative: 25, IsAlive: true},
+		{ID: 2, Name: "Goblin", IsNPC: true, Team: 1, Initiative: 15, IsAlive: true},
+	}
+	
+	combat := &Combat{
+		ID:           1,
+		Participants: participants,
+	}
+	
+	// Roll initiative to set turn order
+	combat.GetTurnOrder()
+	
+	turnOrder := ui.renderTurnOrder(combat)
+	
+	if !strings.Contains(turnOrder, "Hero") {
+		t.Error("Turn order should contain 'Hero'")
+	}
+	
+	if !strings.Contains(turnOrder, "Goblin") {
+		t.Error("Turn order should contain 'Goblin'")
+	}
+}
+
+func TestCombatUI_RenderCombatLog(t *testing.T) {
+	ui := NewCombatUI(80, 24)
+	
+	combat := &Combat{
+		ID: 1,
+		Log: []CombatLogEntry{
+			{Tick: 1, Message: "Hero attacks Goblin", Type: "damage"},
+			{Tick: 2, Message: "Goblin takes 10 damage", Type: "damage"},
+			{Tick: 3, Message: "Hero healed for 5", Type: "heal"},
+		},
+	}
+	
+	logOutput := ui.renderCombatLog(combat, 3)
+	
+	if !strings.Contains(logOutput, "Combat Log") {
+		t.Error("Combat log should contain header")
+	}
+}
+
+func TestCombatUI_RenderPlayerStatus(t *testing.T) {
+	ui := NewCombatUI(80, 24)
+	
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, HP: 80, MaxHP: 100, Mana: 50, MaxMana: 100, Stamina: 60, MaxStamina: 100},
+	}
+	
+	combat := &Combat{
+		ID:           1,
+		Participants: participants,
+	}
+	
+	status := ui.renderPlayerStatus(combat, 1)
+	
+	if !strings.Contains(status, "HP") {
+		t.Error("Player status should contain HP")
+	}
+	
+	if !strings.Contains(status, "Mana") {
+		t.Error("Player status should contain Mana")
+	}
+	
+	if !strings.Contains(status, "STA") {
+		t.Error("Player status should contain Stamina")
+	}
+}
+
+func TestCombatUI_RenderActionBar(t *testing.T) {
+	ui := NewCombatUI(80, 24)
+	
+	combat := &Combat{
+		ID: 1,
+		Participants: []*Participant{
+			{ID: 1, Name: "Hero", IsPlayer: true, Team: 0},
+		},
+	}
+	
+	im := NewInputManager(DefaultInputConfig())
+	im.RegisterParticipant(combat.Participants[0])
+	
+	actionBar := ui.renderActionBar(combat, 1, im)
+	
+	if !strings.Contains(actionBar, "attack") && !strings.Contains(actionBar, "Attack") {
+		t.Error("Action bar should contain attack action")
+	}
+}
+
+func TestRenderCompactHPBar(t *testing.T) {
+	// Full HP
+	bar := RenderCompactHPBar(100, 100)
+	if !strings.Contains(bar, "100/100") {
+		t.Error("Compact HP bar should show HP values")
+	}
+	
+	// Half HP
+	bar = RenderCompactHPBar(50, 100)
+	if !strings.Contains(bar, "50/100") {
+		t.Error("Compact HP bar should show HP values")
+	}
+}
+
+func TestFormatTimeRemaining(t *testing.T) {
+	// 1 second
+	formatted := FormatTimeRemaining(time.Second)
+	if formatted != "1.0" {
+		t.Errorf("Expected '1.0', got '%s'", formatted)
+	}
+	
+	// 1.5 seconds
+	formatted = FormatTimeRemaining(1500 * time.Millisecond)
+	if formatted != "1.5" {
+		t.Errorf("Expected '1.5', got '%s'", formatted)
+	}
+	
+	// Negative (should return 0.0)
+	formatted = FormatTimeRemaining(-time.Second)
+	if formatted != "0.0" {
+		t.Errorf("Expected '0.0' for negative, got '%s'", formatted)
+	}
+}
+
+func TestCombatUI_Render_Full(t *testing.T) {
+	ui := NewCombatUI(80, 24)
+	
+	participants := []*Participant{
+		{ID: 1, Name: "Hero", IsPlayer: true, Team: 0, HP: 80, MaxHP: 100, Mana: 50, MaxMana: 100, Stamina: 60, MaxStamina: 100, Dexterity: 15, IsAlive: true},
+		{ID: 2, Name: "Goblin", IsNPC: true, Team: 1, HP: 30, MaxHP: 50, Dexterity: 10, IsAlive: true},
+	}
+	
+	combat := &Combat{
+		ID:           1,
+		RoomID:       5,
+		Participants: participants,
+		State:        StateActive,
+		TickNumber:   1,
+		ActionQueue:  NewActionQueue(),
+		Effects:      NewEffectRegistry(),
+	}
+	
+	tm := NewTickManager()
+	cm := NewCombatManager()
+	sm := NewCombatStateMachine(combat, cm, tm)
+	im := NewInputManager(DefaultInputConfig())
+	
+	for _, p := range participants {
+		im.RegisterParticipant(p)
+	}
+	
+	// Roll initiative
+	combat.GetTurnOrder()
+	
+	// Start input window
+	sm.currentActorIdx = 0
+	im.StartInputWindow(1)
+	
+	rendered := ui.Render(combat, sm, im, 1)
+	
+	// Should contain all major sections
+	if !strings.Contains(rendered, "COMBAT") {
+		t.Error("Full render should contain combat title")
+	}
+	
+	if !strings.Contains(rendered, "Enemy") || !strings.Contains(rendered, "Goblin") {
+		t.Error("Full render should contain enemy section")
+	}
+	
+	if !strings.Contains(rendered, "Turn Order") {
+		t.Error("Full render should contain turn order")
+	}
+	
+	if !strings.Contains(rendered, "Combat Log") {
+		t.Error("Full render should contain combat log")
+	}
+	
+	if !strings.Contains(rendered, "Status") {
+		t.Error("Full render should contain player status")
+	}
+	
+	if !strings.Contains(rendered, "Action") {
+		t.Error("Full render should contain action bar")
+	}
+}

--- a/herbst/main.go
+++ b/herbst/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/charmbracelet/wish/logging"
 	_ "github.com/lib/pq"
 	"github.com/muesli/termenv"
+	"herbst/combat"
 	"herbst/db"
 	"herbst/db/character"
 	"herbst/db/user"


### PR DESCRIPTION
## Summary
Merges combat phase 2 features from the original combat-phase2 branch into current main.

### Features Added
- Action queue and definitions with tick costs
- Combat state machine with lifecycle management  
- Input timing and auto-action system
- Combat UI with HP bars and action bar
- Damage resolution formula
- Interrupt mechanics (parry, shield bash, stun)
- Victory/defeat screens with loot
- Weapon drop system
- Examine skill with hidden details

### Files Changed
- 29 new files in herbst/combat/
- Main.go updated to import combat package

## Test Plan
- [ ] Run go test ./herbst/combat/...
- [ ] Verify combat UI displays correctly
- [ ] Test interrupt mechanics in combat

Closes #128