### PR TITLE
feat(admin): Create exits by dragging (admin-06)

### DIFF
--- a/admin/src/components/DirectionPicker.test.tsx
+++ b/admin/src/components/DirectionPicker.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DirectionPicker } from './DirectionPicker'
+
+describe('DirectionPicker', () => {
+  const defaultProps = {
+    isOpen: true,
+    sourceId: '1',
+    targetId: '2',
+    sourceName: 'Town Square',
+    targetName: 'Main Street',
+    onSelect: vi.fn(),
+    onCancel: vi.fn(),
+  }
+
+  it('renders when open', () => {
+    render(<DirectionPicker {...defaultProps} />)
+    expect(screen.getByText('Select Exit Direction')).toBeDefined()
+    expect(screen.getByText(/Town Square/)).toBeDefined()
+    expect(screen.getByText(/Main Street/)).toBeDefined()
+  })
+
+  it('does not render when closed', () => {
+    render(<DirectionPicker {...defaultProps} isOpen={false} />)
+    expect(screen.queryByText('Select Exit Direction')).toBeNull()
+  })
+
+  it('calls onCancel when Cancel is clicked', () => {
+    render(<DirectionPicker {...defaultProps} />)
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(defaultProps.onCancel).toHaveBeenCalled()
+  })
+
+  it('calls onSelect with direction when Save Exit is clicked after selecting direction', () => {
+    render(<DirectionPicker {...defaultProps} />)
+    
+    // Click on North direction
+    fireEvent.click(screen.getByText('North'))
+    
+    // Click Save Exit
+    fireEvent.click(screen.getByText('Save Exit'))
+    
+    expect(defaultProps.onSelect).toHaveBeenCalledWith('north', 'south')
+  })
+
+  it('displays all six directions', () => {
+    render(<DirectionPicker {...defaultProps} />)
+    expect(screen.getByText('North')).toBeDefined()
+    expect(screen.getByText('South')).toBeDefined()
+    expect(screen.getByText('East')).toBeDefined()
+    expect(screen.getByText('West')).toBeDefined()
+    expect(screen.getByText('Up')).toBeDefined()
+    expect(screen.getByText('Down')).toBeDefined()
+  })
+})

--- a/admin/src/components/DirectionPicker.tsx
+++ b/admin/src/components/DirectionPicker.tsx
@@ -1,0 +1,152 @@
+import { useState } from 'react'
+
+export interface DirectionPickerProps {
+  isOpen: boolean
+  sourceId: string
+  targetId: string
+  sourceName: string
+  targetName: string
+  onSelect: (direction: string, reverseDirection: string) => void
+  onCancel: () => void
+}
+
+const DIRECTIONS = [
+  { id: 'north', label: 'North', symbol: 'N', reverse: 'south' },
+  { id: 'south', label: 'South', symbol: 'S', reverse: 'north' },
+  { id: 'east', label: 'East', symbol: 'E', reverse: 'west' },
+  { id: 'west', label: 'West', symbol: 'W', reverse: 'east' },
+  { id: 'up', label: 'Up', symbol: 'U', reverse: 'down' },
+  { id: 'down', label: 'Down', symbol: 'D', reverse: 'up' },
+]
+
+export function DirectionPicker({
+  isOpen,
+  sourceId: _sourceId,
+  targetId: _targetId,
+  sourceName,
+  targetName,
+  onSelect,
+  onCancel,
+}: DirectionPickerProps) {
+  const [selectedDirection, setSelectedDirection] = useState<string | null>(null)
+
+  if (!isOpen) return null
+
+  const handleConfirm = () => {
+    if (!selectedDirection) return
+    const direction = DIRECTIONS.find(d => d.id === selectedDirection)
+    if (direction) {
+      onSelect(direction.id, direction.reverse)
+    }
+  }
+
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      background: 'rgba(0, 0, 0, 0.7)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 1000,
+    }}>
+      <div style={{
+        background: '#1a1a2e',
+        border: '2px solid #6c5ce7',
+        borderRadius: '12px',
+        padding: '24px',
+        minWidth: '320px',
+        boxShadow: '0 8px 32px rgba(108, 92, 231, 0.4)',
+      }}>
+        <h3 style={{ 
+          margin: '0 0 16px 0', 
+          color: '#fff',
+          textAlign: 'center',
+        }}>
+          Select Exit Direction
+        </h3>
+        
+        <div style={{
+          marginBottom: '16px',
+          padding: '12px',
+          background: '#16213e',
+          borderRadius: '8px',
+          color: '#aaa',
+          fontSize: '14px',
+        }}>
+          <div><strong style={{ color: '#6c5ce7' }}>{sourceName}</strong> to <strong style={{ color: '#6c5ce7' }}>{targetName}</strong></div>
+        </div>
+
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 1fr)',
+          gap: '8px',
+          marginBottom: '20px',
+        }}>
+          {DIRECTIONS.map(dir => (
+            <button
+              key={dir.id}
+              onClick={() => setSelectedDirection(dir.id)}
+              style={{
+                padding: '12px 8px',
+                background: selectedDirection === dir.id ? '#6c5ce7' : '#2d2d44',
+                border: selectedDirection === dir.id ? '2px solid #a29bfe' : '2px solid #444',
+                borderRadius: '8px',
+                color: '#fff',
+                cursor: 'pointer',
+                transition: 'all 0.2s ease',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: '4px',
+              }}
+            >
+              <span style={{ fontSize: '20px', fontWeight: 'bold' }}>{dir.symbol}</span>
+              <span style={{ fontSize: '12px' }}>{dir.label}</span>
+            </button>
+          ))}
+        </div>
+
+        <div style={{
+          display: 'flex',
+          gap: '12px',
+          justifyContent: 'center',
+        }}>
+          <button
+            onClick={onCancel}
+            style={{
+              padding: '10px 24px',
+              background: 'transparent',
+              border: '2px solid #666',
+              borderRadius: '6px',
+              color: '#aaa',
+              cursor: 'pointer',
+              fontSize: '14px',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={!selectedDirection}
+            style={{
+              padding: '10px 24px',
+              background: selectedDirection ? '#27ae60' : '#333',
+              border: 'none',
+              borderRadius: '6px',
+              color: '#fff',
+              cursor: selectedDirection ? 'pointer' : 'not-allowed',
+              fontSize: '14px',
+              fontWeight: 'bold',
+            }}
+          >
+            Save Exit
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/admin/src/components/RoomNode.tsx
+++ b/admin/src/components/RoomNode.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useState } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import type { NodeProps } from '@xyflow/react'
 
@@ -17,26 +17,39 @@ const truncateText = (text: string, maxLength: number): string => {
 function RoomNodeComponent({ data, selected }: NodeProps) {
   const roomData = data as unknown as RoomNodeData
   const showZLevel = roomData.zLevel !== 0
+  const [isHovered, setIsHovered] = useState(false)
+  
+  const handleStyle = {
+    background: '#6c5ce7',
+    width: '10px',
+    height: '10px',
+    border: '2px solid #fff',
+    transition: 'all 0.2s ease',
+  }
   
   return (
-    <div style={{
-      padding: '12px 16px',
-      borderRadius: '8px',
-      background: selected ? '#1a3a2f' : '#2d5a27',
-      border: selected ? '2px solid #6c5ce7' : '2px solid #3a7a3a',
-      minWidth: '160px',
-      maxWidth: '200px',
-      boxShadow: selected ? '0 0 12px rgba(108, 92, 231, 0.5)' : '0 2px 8px rgba(0,0,0,0.3)',
-      cursor: 'grab',
-      transition: 'all 0.2s ease',
-    }}>
-      {/* Handles for connections */}
-      <Handle type="target" position={Position.Top} style={{ background: '#555' }} />
-      <Handle type="source" position={Position.Bottom} style={{ background: '#555' }} />
-      <Handle type="target" position={Position.Left} id="left-target" style={{ background: '#555' }} />
-      <Handle type="source" position={Position.Left} id="left-source" style={{ background: '#555' }} />
-      <Handle type="target" position={Position.Right} id="right-target" style={{ background: '#555' }} />
-      <Handle type="source" position={Position.Right} id="right-source" style={{ background: '#555' }} />
+    <div 
+      style={{
+        padding: '12px 16px',
+        borderRadius: '8px',
+        background: selected ? '#1a3a2f' : '#2d5a27',
+        border: selected ? '2px solid #6c5ce7' : '2px solid #3a7a3a',
+        minWidth: '160px',
+        maxWidth: '200px',
+        boxShadow: selected ? '0 0 12px rgba(108, 92, 231, 0.5)' : '0 2px 8px rgba(0,0,0,0.3)',
+        cursor: 'grab',
+        transition: 'all 0.2s ease',
+      }}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      {/* Handles for connections - shown on hover */}
+      <Handle type="target" position={Position.Top} style={{ ...handleStyle, opacity: isHovered ? 1 : 0.3 }} />
+      <Handle type="source" position={Position.Bottom} style={{ ...handleStyle, opacity: isHovered ? 1 : 0.3 }} />
+      <Handle type="target" position={Position.Left} id="left-target" style={{ ...handleStyle, opacity: isHovered ? 1 : 0.3 }} />
+      <Handle type="source" position={Position.Left} id="left-source" style={{ ...handleStyle, opacity: isHovered ? 1 : 0.3 }} />
+      <Handle type="target" position={Position.Right} id="right-target" style={{ ...handleStyle, opacity: isHovered ? 1 : 0.3 }} />
+      <Handle type="source" position={Position.Right} id="right-source" style={{ ...handleStyle, opacity: isHovered ? 1 : 0.3 }} />
       
       {/* Room name - bold */}
       <div style={{

--- a/admin/src/routes/admin/map.tsx
+++ b/admin/src/routes/admin/map.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useState, useCallback } from 'react'
 import { MapFlow } from '../../components/MapFlow'
+import { DirectionPicker } from '../../components/DirectionPicker'
 import type { Node, Edge, Connection } from '@xyflow/react'
 
 export const Route = createFileRoute('/admin/map')({
@@ -11,6 +12,13 @@ interface MapRoomData extends Record<string, unknown> {
   name: string
   description: string
   zLevel: number
+}
+
+interface PendingConnection {
+  source: string
+  target: string
+  sourceName: string
+  targetName: string
 }
 
 function MapBuilder() {
@@ -60,6 +68,7 @@ function MapBuilder() {
   ])
 
   const [selectedNode, setSelectedNode] = useState<Node | null>(null)
+  const [pendingConnection, setPendingConnection] = useState<PendingConnection | null>(null)
 
   const onNodeClick = useCallback((_: React.MouseEvent, node: Node) => {
     setSelectedNode(node)
@@ -71,17 +80,56 @@ function MapBuilder() {
 
   const onConnect = useCallback((connection: Connection) => {
     if (connection.source && connection.target) {
-      const direction = connection.sourceHandle || 'connected'
-      setEdges(eds => [...eds, {
-        id: `e${connection.source}-${connection.target}`,
-        source: connection.source!,
-        target: connection.target!,
+      // Find the source and target node names
+      const sourceNode = nodes.find(n => n.id === connection.source)
+      const targetNode = nodes.find(n => n.id === connection.target)
+      
+      if (sourceNode && targetNode) {
+        // Store pending connection and show direction picker
+        const sourceData = sourceNode.data as MapRoomData
+        const targetData = targetNode.data as MapRoomData
+        setPendingConnection({
+          source: connection.source,
+          target: connection.target,
+          sourceName: sourceData.name || 'Unknown',
+          targetName: targetData.name || 'Unknown',
+        })
+      }
+    }
+  }, [nodes])
+
+  const handleDirectionSelect = (direction: string, reverseDirection: string) => {
+    if (!pendingConnection) return
+    
+    // Create bidirectional exits
+    const newEdges: Edge[] = [
+      {
+        id: `e${pendingConnection.source}-${pendingConnection.target}-${direction}`,
+        source: pendingConnection.source,
+        target: pendingConnection.target,
         label: direction,
         type: 'smoothstep',
-        animated: true
-      }])
-    }
-  }, [])
+        animated: true,
+        style: { stroke: '#6c5ce7', strokeWidth: 2 },
+      },
+      {
+        id: `e${pendingConnection.target}-${pendingConnection.source}-${reverseDirection}`,
+        source: pendingConnection.target,
+        target: pendingConnection.source,
+        label: reverseDirection,
+        type: 'smoothstep',
+        animated: true,
+        style: { stroke: '#6c5ce7', strokeWidth: 2 },
+      },
+    ]
+    
+    setEdges(eds => [...eds, ...newEdges])
+    setPendingConnection(null)
+  }
+
+  const handleConnectionCancel = () => {
+    setPendingConnection(null)
+  }
 
   const addNewRoom = () => {
     const newId = String(nodes.length + 1)
@@ -196,6 +244,17 @@ function MapBuilder() {
         <span style={{ marginLeft: '16px' }}>➡️ Exit Connection</span>
         <span style={{ marginLeft: '16px' }}>🟦 Selected</span>
       </div>
+
+      {/* Direction Picker Modal */}
+      <DirectionPicker
+        isOpen={pendingConnection !== null}
+        sourceId={pendingConnection?.source || ''}
+        targetId={pendingConnection?.target || ''}
+        sourceName={pendingConnection?.sourceName || ''}
+        targetName={pendingConnection?.targetName || ''}
+        onSelect={handleDirectionSelect}
+        onCancel={handleConnectionCancel}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Implements Issue #154: Create Exit Connections by Dragging

### Changes
- **DirectionPicker.tsx** - New modal component for selecting exit direction when connecting rooms
- **DirectionPicker.test.tsx** - Unit tests (5 passing)
- **RoomNode.tsx** - Updated to show connection handles on hover
- **map.tsx** - Modified to show direction picker when connections are made, creates bidirectional exits

### Features
- Hover over room node to reveal connection handles
- Drag from one room to another to initiate exit creation
- Direction picker modal appears to select exit direction (N/S/E/W/Up/Down)
- Creates bidirectional exits automatically (e.g., north + south)

### Tests
All 8 tests pass (3 Sidebar + 5 DirectionPicker)

Closes #154