### PR TITLE
feat(faction-005): auto-grant first_class tag on character creation

### DIFF
--- a/server/services/character.go
+++ b/server/services/character.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"herbst-server/constants"
 	"herbst-server/db"
@@ -176,6 +177,12 @@ func (s *CharacterService) CreateCharacter(ctx context.Context, input CreateChar
 	// Apply race stat modifiers from DB
 	char, _ = dbinit.ApplyRaceToCharacter(ctx, s.client, char)
 
+	// Auto-grant first_class tag on character creation
+	if grantErr := s.GrantTag(ctx, char.ID, "first_class", "system"); grantErr != nil {
+		// Log but don't fail character creation if tag grant fails
+		fmt.Printf("Warning: failed to grant first_class tag to character %d: %v\n", char.ID, grantErr)
+	}
+
 	return char, nil
 }
 
@@ -195,4 +202,14 @@ func HashPassword(password string) (string, error) {
 		return "", err
 	}
 	return string(hash), nil
+}
+
+// GrantTag adds a tag to a character with the given source.
+func (s *CharacterService) GrantTag(ctx context.Context, characterID int, tag, source string) error {
+	_, err := s.client.CharacterTag.Create().
+		SetTag(tag).
+		SetSource(source).
+		SetCharacterID(characterID).
+		Save(ctx)
+	return err
 }


### PR DESCRIPTION
## FACTION-005: Auto-grant first_class tag on character creation

Implements RFC-FACTION-SKILLS — every new character automatically receives `first_class` tag with source `system`.

### What this PR does

**Service change** (`server/services/character.go`):
- Added `GrantTag(ctx, characterID, tag, source)` method to `CharacterService`
- Called after `CreateCharacter` succeeds:
  ```go
  s.GrantTag(ctx, char.ID, "first_class", "system")
  ```
- Tag grant failure is logged but does NOT fail character creation (defensive — DB issues with tags don't break core flow)

### Verification
- [ ] New characters have `first_class` tag
- [ ] Tag source is `system`
- [ ] Tag appears in `GET /characters/:id/tags`
- [ ] `go build ./...` passes

### Related
- Closes #298
- Part of RFC-FACTION-SKILLS §Implementation Notes
