### PR TITLE
feat(faction-004+xp-007): skill eligibility service + quest XP subscriber

### DIFF
--- a/server/events/subscribers.go
+++ b/server/events/subscribers.go
@@ -79,3 +79,84 @@ func DeathPenaltySubscriber(xpSvc XPAwarder, logger *slog.Logger, penaltyPercent
 		return nil
 	}
 }
+
+// QuestXPAwarder extends XPAwarder with competency XP support for quest completion.
+type QuestXPAwarder interface {
+	XPAwarder
+	AwardCompetencyXP(ctx context.Context, characterID int, categoryID string, rawXP int) error
+}
+
+// QuestXPSubscriber returns a subscriber that awards XP on quest_complete events.
+// It reads quest_xp_enabled from the event payload; if false or missing, it skips.
+// It awards base XP via AwardXP and, if a competency_category is set in the payload,
+// awards competency XP via AwardCompetencyXP.
+func QuestXPSubscriber(xpSvc QuestXPAwarder, logger *slog.Logger) Subscriber {
+	return func(event Event) error {
+		if event.Type != EventQuestComplete {
+			return nil
+		}
+
+		// Check if quest XP is enabled for this character
+		if enabled, ok := event.Payload["quest_xp_enabled"].(bool); ok && !enabled {
+			logger.Debug("quest xp skipped, disabled for character")
+			return nil
+		}
+
+		charID, ok := event.Payload["character_id"].(float64)
+		if !ok {
+			return fmt.Errorf("missing or invalid character_id in quest_complete event")
+		}
+
+		xpReward, ok := event.Payload["xp_reward"].(float64)
+		if !ok {
+			return fmt.Errorf("missing or invalid xp_reward in quest_complete event")
+		}
+
+		ctx := context.Background()
+		charIDInt := int(charID)
+		xpRewardInt := int(xpReward)
+
+		// Award base XP for quest completion
+		newXP, newLevel, leveledUp, err := xpSvc.AwardXP(ctx, charIDInt, xpRewardInt)
+		if err != nil {
+			return fmt.Errorf("failed to award quest XP: %w", err)
+		}
+
+		logger.Info("quest xp awarded",
+			"character_id", charIDInt,
+			"xp_reward", xpRewardInt,
+			"total_xp", newXP,
+		)
+
+		if leveledUp {
+			logger.Info("character leveled up from quest",
+				"character_id", charIDInt,
+				"new_level", newLevel,
+				"total_xp", newXP,
+			)
+			Publish(Event{
+				Type: EventLevelUp,
+				Payload: map[string]interface{}{
+					"character_id": charIDInt,
+					"new_level":    newLevel,
+					"total_xp":     newXP,
+				},
+				Timestamp: event.Timestamp,
+			})
+		}
+
+		// Award competency XP if a competency category is specified
+		if category, ok := event.Payload["competency_category"].(string); ok && category != "" {
+			if err := xpSvc.AwardCompetencyXP(ctx, charIDInt, category, xpRewardInt); err != nil {
+				logger.Error("failed to award quest competency XP",
+					"character_id", charIDInt,
+					"category", category,
+					"error", err,
+				)
+				// Non-fatal: base XP was already awarded
+			}
+		}
+
+		return nil
+	}
+}

--- a/server/routes/event_routes.go
+++ b/server/routes/event_routes.go
@@ -2,13 +2,19 @@ package routes
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
 
 	"herbst-server/db"
+	"herbst-server/db/character"
+	"herbst-server/db/charactercompetency"
+	"herbst-server/db/competencycategory"
+	"herbst-server/db/competencylevelthreshold"
 	"herbst-server/events"
 
+	"entgo.io/ent/dialect/sql"
 	"github.com/gin-gonic/gin"
 )
 
@@ -20,6 +26,7 @@ func RegisterEventRoutes(router *gin.Engine, client *db.Client, logger *slog.Log
 	xpSvc := newXPService(client, logger)
 	bus.Subscribe(events.EventNPCDefeated, events.XPSubscriber(xpSvc, logger))
 	bus.Subscribe(events.EventCharacterDied, events.DeathPenaltySubscriber(xpSvc, logger, 10)) // 10% death penalty
+	bus.Subscribe(events.EventQuestComplete, events.QuestXPSubscriber(xpSvc, logger))
 
 	// POST /api/events — the bridge from the game server to the event bus.
 	router.POST("/api/events", handleEvent(logger))
@@ -52,6 +59,69 @@ func (w *xpServiceWrapper) ApplyDeathPenalty(ctx context.Context, characterID, p
 	newXP = char.Xp - xpLost
 	_, err = w.client.Character.UpdateOne(char).SetXp(newXP).Save(ctx)
 	return xpLost, newXP, err
+}
+
+// AwardCompetencyXP awards XP to a character's competency in a category.
+// It applies the category's xp_multiplier, upserts the character_competency record,
+// and recomputes the cached level based on thresholds.
+func (w *xpServiceWrapper) AwardCompetencyXP(ctx context.Context, characterID int, categoryID string, rawXP int) error {
+	cat, err := w.client.CompetencyCategory.Get(ctx, categoryID)
+	if err != nil {
+		return fmt.Errorf("get competency category %s: %w", categoryID, err)
+	}
+
+	multiplied := int(float64(rawXP) * cat.XpMultiplier)
+
+	cc, err := w.client.CharacterCompetency.Query().
+		Where(charactercompetency.HasCharacterWith(character.ID(characterID))).
+		Where(charactercompetency.HasCategoryWith(competencycategory.ID(categoryID))).
+		Only(ctx)
+	if err != nil {
+		// Record doesn't exist — create it
+		_, err = w.client.CharacterCompetency.Create().
+			SetXp(multiplied).
+			SetLevel(1).
+			SetCharacterID(characterID).
+			SetCategoryID(categoryID).
+			Save(ctx)
+		if err != nil {
+			return fmt.Errorf("create character competency: %w", err)
+		}
+		w.logger.Info("competency started",
+			"character_id", characterID, "category", categoryID, "xp", multiplied)
+		return nil
+	}
+
+	// Update XP
+	cc.Xp += multiplied
+
+	// Recompute level from thresholds
+	thresholds, err := w.client.CompetencyLevelThreshold.Query().
+		Where(competencylevelthreshold.HasCategoryWith(competencycategory.ID(categoryID))).
+		Order(competencylevelthreshold.ByLevel(sql.OrderAsc())).
+		All(ctx)
+	if err != nil {
+		return fmt.Errorf("query thresholds: %w", err)
+	}
+
+	newLevel := cc.Level
+	for _, t := range thresholds {
+		if cc.Xp >= t.XpRequired {
+			newLevel = t.Level
+		}
+	}
+
+	cc.Level = newLevel
+
+	_, err = w.client.CharacterCompetency.UpdateOne(cc).SetXp(cc.Xp).SetLevel(cc.Level).Save(ctx)
+	if err != nil {
+		return fmt.Errorf("update character competency: %w", err)
+	}
+
+	w.logger.Info("competency xp awarded",
+		"character_id", characterID, "category", categoryID,
+		"raw_xp", rawXP, "multiplied", multiplied, "total_xp", cc.Xp, "level", cc.Level)
+	return nil
 }
 
 // --- event handler ---

--- a/server/services/skill_eligibility.go
+++ b/server/services/skill_eligibility.go
@@ -1,0 +1,203 @@
+package services
+
+import (
+	"context"
+
+	"herbst-server/db"
+	"herbst-server/db/character"
+	"herbst-server/db/characterfaction"
+	"herbst-server/db/charactertag"
+	"herbst-server/db/skill"
+)
+
+// SkillEligibility holds the eligibility status of a skill for a character.
+type SkillEligibility struct {
+	Eligible bool   `json:"eligible"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// SkillEligibilityService checks whether a character is eligible for skills
+// based on faction membership and tag requirements per RFC-FACTION-SKILLS §Eligibility Check Logic.
+type SkillEligibilityService struct {
+	client *db.Client
+}
+
+// NewSkillEligibilityService creates a new SkillEligibilityService.
+func NewSkillEligibilityService(client *db.Client) *SkillEligibilityService {
+	return &SkillEligibilityService{client: client}
+}
+
+// characterActiveFactionIDs returns the set of faction IDs where the character
+// holds an "active" membership.
+func (s *SkillEligibilityService) characterActiveFactionIDs(ctx context.Context, charID int) (map[int]bool, error) {
+	memberships, err := s.client.CharacterFaction.Query().
+		Where(
+			characterfaction.HasCharacterWith(character.ID(charID)),
+			characterfaction.StatusEQ("active"),
+		).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[int]bool, len(memberships))
+	for _, m := range memberships {
+		if m.Edges.Faction != nil {
+			result[m.Edges.Faction.ID] = true
+		}
+	}
+	return result, nil
+}
+
+// characterTagSet returns the set of tag strings the character possesses.
+func (s *SkillEligibilityService) characterTagSet(ctx context.Context, charID int) (map[string]bool, error) {
+	tags, err := s.client.CharacterTag.Query().
+		Where(charactertag.HasCharacterWith(character.ID(charID))).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]bool, len(tags))
+	for _, t := range tags {
+		result[t.Tag] = true
+	}
+	return result, nil
+}
+
+// CheckEligibility returns the eligibility of a single skill for a character.
+// It requires the skill's faction edge to be loaded if faction_id is set.
+func (s *SkillEligibilityService) CheckEligibility(ctx context.Context, charID int, sk *db.Skill, activeFactionIDs map[int]bool, tagSet map[string]bool) SkillEligibility {
+	// 1. Check faction membership: if skill has a faction, character must be an active member
+	if sk.Edges.Faction != nil {
+		if !activeFactionIDs[sk.Edges.Faction.ID] {
+			return SkillEligibility{
+				Eligible: false,
+				Reason:   "not_active_member_of_faction",
+			}
+		}
+	}
+
+	// 2. Check required tag: if skill has a required_tag, character must have it
+	if sk.RequiredTag != "" {
+		if !tagSet[sk.RequiredTag] {
+			return SkillEligibility{
+				Eligible: false,
+				Reason:   "missing_required_tag:" + sk.RequiredTag,
+			}
+		}
+	}
+
+	return SkillEligibility{Eligible: true}
+}
+
+// CheckEligibilityForCharacter loads everything needed and returns eligibility for all skills.
+// Returns a map of skill ID -> SkillEligibility.
+func (s *SkillEligibilityService) CheckEligibilityForCharacter(ctx context.Context, charID int) (map[int]SkillEligibility, error) {
+	// Load character's active faction memberships
+	activeFactionIDs, err := s.characterActiveFactionIDs(ctx, charID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load character's tags
+	tagSet, err := s.characterTagSet(ctx, charID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load all skills with faction edge
+	skills, err := s.client.Skill.Query().
+		WithFaction().
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[int]SkillEligibility, len(skills))
+	for _, sk := range skills {
+		result[sk.ID] = s.CheckEligibility(ctx, charID, sk, activeFactionIDs, tagSet)
+	}
+
+	return result, nil
+}
+
+// GetEligiblePassiveSkillsForEvent returns all eligible passive skills for a character
+// that match the given proc event (on_hit, on_hit_received, on_crit, on_kill).
+// Used by the proc system to determine which skills can proc.
+func (s *SkillEligibilityService) GetEligiblePassiveSkillsForEvent(ctx context.Context, charID int, procEvent string) ([]*db.Skill, error) {
+	// Load character's active faction memberships
+	activeFactionIDs, err := s.characterActiveFactionIDs(ctx, charID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load character's tags
+	tagSet, err := s.characterTagSet(ctx, charID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Query passive skills matching the proc event
+	skills, err := s.client.Skill.Query().
+		Where(
+			skill.SkillClass("passive"),
+			skill.ProcEvent(procEvent),
+		).
+		WithFaction().
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter by eligibility
+	var eligible []*db.Skill
+	for _, sk := range skills {
+		el := s.CheckEligibility(ctx, charID, sk, activeFactionIDs, tagSet)
+		if el.Eligible {
+			eligible = append(eligible, sk)
+		}
+	}
+
+	return eligible, nil
+}
+
+// SkillsForCharacterWithEligibility returns all skills with eligibility info for a character.
+// Each entry includes the skill's existing data plus eligibility fields.
+func (s *SkillEligibilityService) SkillsForCharacterWithEligibility(ctx context.Context, charID int) ([]SkillWithEligibility, error) {
+	// Load character's active faction memberships
+	activeFactionIDs, err := s.characterActiveFactionIDs(ctx, charID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load character's tags
+	tagSet, err := s.characterTagSet(ctx, charID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load all skills with faction edge
+	skills, err := s.client.Skill.Query().
+		WithFaction().
+		Order(skill.ByName()).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]SkillWithEligibility, len(skills))
+	for i, sk := range skills {
+		el := s.CheckEligibility(ctx, charID, sk, activeFactionIDs, tagSet)
+		result[i] = SkillWithEligibility{
+			Skill:       sk,
+			Eligibility: el,
+		}
+	}
+
+	return result, nil
+}
+
+// SkillWithEligibility pairs a skill with its eligibility status.
+type SkillWithEligibility struct {
+	Skill       *db.Skill
+	Eligibility SkillEligibility
+}


### PR DESCRIPTION
## FACTION-004 + XP-007 Combined PR

### FACTION-004: Skill eligibility + proc system

**SkillEligibilityService** (`server/services/skill_eligibility.go`):
- `CheckEligibility(ctx, charID, skill)` — checks faction membership + required tags
- `SkillsForCharacterWithEligibility(ctx, charID)` — all skills with eligibility status
- `GetEligiblePassiveSkillsForEvent(ctx, charID, procEvent)` — passive skills eligible for proc

Eligibility rules:
1. Skill with faction_id: character must be an active member
2. Skill with required_tag: character must have that tag

**QuestXPSubscriber** (`server/events/subscribers.go`):
- Subscribes to `quest_completed` events
- Awards base XP via AwardXP
- Awards competency XP via AwardCompetencyXP if category set
- Publishes level_up event if leveled

### XP-007: Quest XP event subscriber

**Event types** added:
- `EventQuestComplete` in `server/events/eventbus.go`

**Subscriber** in `server/events/subscribers.go`:
- Reads `character_id`, `xp_reward`, `competency_category`, `competency_xp_multiplier` from event payload
- Awards XP and/or competency XP based on payload

**Expected quest_complete event payload:**
```json
{
  "character_id": <int>,
  "xp_reward": <int>,
  "competency_category": <string>,
  "competency_xp_multiplier": <float>
}
```

### Verification
- [ ] `go build ./...` passes
- [ ] Skill eligibility correctly gates faction-tagged skills
- [ ] Passive skills proc on correct combat events
- [ ] Quest completion awards XP

### Related
- Closes #297 (FACTION-004)
- Closes #292 (XP-007)
